### PR TITLE
Add interactive HVAC duct sizing guide at /hvac

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -26,6 +26,10 @@ export default function (eleventyConfig) {
     // copy, so the watcher needs to be told about it for `npm start` to rebuild.
     eleventyConfig.addWatchTarget("./src/_hvac/");
 
+    // Its docs are for developers, not visitors. Markdown is a template format,
+    // so without this the directory's README would publish as a page.
+    eleventyConfig.ignores.add("src/_hvac/**/*.md");
+
     // Shortcodes
     eleventyConfig.addShortcode('year', year);
     eleventyConfig.addShortcode('convertTime', convertTime);

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -22,6 +22,10 @@ export default function (eleventyConfig) {
     // Passthrough copy
     eleventyConfig.addPassthroughCopy("src/assets");
 
+    // The /hvac applet is build input rather than a template or a passthrough
+    // copy, so the watcher needs to be told about it for `npm start` to rebuild.
+    eleventyConfig.addWatchTarget("./src/_hvac/");
+
     // Shortcodes
     eleventyConfig.addShortcode('year', year);
     eleventyConfig.addShortcode('convertTime', convertTime);

--- a/README.md
+++ b/README.md
@@ -56,10 +56,28 @@ This command:
 3.  Optimizes images.
 4.  Bundles JavaScript via esbuild.
 
+## 🌬️ The `/hvac` applet
+
+`/hvac` is a self-contained React app — an interactive guide to sizing and
+installing HVAC ductwork. It lives in `src/_hvac/` and ships as its own JS and CSS
+bundle, so the rest of the site is unaffected and visitors to either one only
+download what that page needs.
+
+- **Content is data.** Lessons live in `src/_hvac/data/` as block lists; a block
+  type maps to one small component in `components/Prose.jsx`. No raw HTML in content.
+- **Math is pure and tested.** Everything the app calculates comes from
+  `lib/ductMath.js`, verified against published ductulator and ASHRAE
+  equivalent-diameter values. Run `npm test`.
+- **One worksheet, eight steps.** `lib/derive.js` turns the worksheet into results,
+  so a change on the airflow screen moves the duct sizes on the sizing screen.
+- **No extra dependencies** beyond `react` and `react-dom` — routing is the URL hash
+  and state is `useState` plus `localStorage`.
+
 ## 📂 Project Structure
 
 - `src/`: Source files.
     - `_data/`: Global data files.
+    - `_hvac/`: React source for the `/hvac` applet (build input, not shipped as-is).
     - `_includes/`: Layouts and partials.
     - `assets/`: Static assets (CSS, JS, Images, Fonts).
     - `projects/`: Project content pages.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,9 @@
         "dotenv": "^16.4.5",
         "git": "^0.1.5",
         "markdown-it-attrs": "^4.1.6",
-        "medium-zoom": "^1.1.0"
+        "medium-zoom": "^1.1.0",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
       },
       "devDependencies": {
         "esbuild": "^0.25.11",
@@ -3790,6 +3792,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3998,6 +4021,12 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/section-matter": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "dotenv": "^16.4.5",
     "git": "^0.1.5",
     "markdown-it-attrs": "^4.1.6",
-    "medium-zoom": "^1.1.0"
+    "medium-zoom": "^1.1.0",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
   },
   "devDependencies": {
     "esbuild": "^0.25.11",
@@ -23,7 +25,7 @@
     "sass": "^1.77.8"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test \"src/_hvac/**/*.test.js\"",
     "start": "eleventy --serve",
     "build": "rimraf public && eleventy"
   }

--- a/src/_11ty/build-assets.js
+++ b/src/_11ty/build-assets.js
@@ -1,30 +1,48 @@
 import esbuild from 'esbuild';
 import fs from "fs";
+import path from "path";
 import * as sass from "sass";
 
+const isProduction = () => process.env.ELEVENTY_RUN_MODE === 'build';
+
+/*
+Each entry becomes one bundle. The site script and the /hvac
+React applet are kept separate so visitors to either one only
+download what that page needs.
+*/
+const JS_BUNDLES = [
+    { entryPoints: ['src/assets/js/index.js'], outfile: 'public/assets/js/bundle.js' },
+    { entryPoints: ['src/_hvac/index.jsx'], outfile: 'public/assets/js/hvac.js', jsx: 'automatic' },
+];
+
+const CSS_BUNDLES = [
+    { entry: 'src/assets/css/style.scss', outfile: 'public/assets/css/style.css', loadPaths: ['src/assets/css/'] },
+    { entry: 'src/_hvac/styles.scss', outfile: 'public/assets/css/hvac.css', loadPaths: ['src/_hvac/'] },
+];
+
 export const buildJs = async () => {
-    await esbuild.build({
-        entryPoints: ['src/assets/js/index.js'],
-        bundle: true,
-        outfile: 'public/assets/js/bundle.js',
-        sourcemap: true, // Optional: for easier debugging
-        minify: process.env.ELEVENTY_RUN_MODE === 'build', // Minify only in production
-    });
+    await Promise.all(
+        JS_BUNDLES.map(({ jsx, ...bundle }) =>
+            esbuild.build({
+                ...bundle,
+                bundle: true,
+                sourcemap: true, // Optional: for easier debugging
+                minify: isProduction(),
+                ...(jsx ? { jsx } : {}),
+            })
+        )
+    );
 };
 
 export const compileSass = () => {
-    // Ensure the output directory exists
-    if (!fs.existsSync("public/assets/css")) {
-        fs.mkdirSync("public/assets/css", { recursive: true });
-    }
+    for (const { entry, outfile, loadPaths } of CSS_BUNDLES) {
+        fs.mkdirSync(path.dirname(outfile), { recursive: true });
 
-    try {
-        let result = sass.compile("src/assets/css/style.scss", {
-            style: "compressed",
-            loadPaths: ["src/assets/css/"]
-        });
-        fs.writeFileSync("public/assets/css/style.css", result.css);
-    } catch (err) {
-        console.error("Sass compilation error:", err);
+        try {
+            const result = sass.compile(entry, { style: "compressed", loadPaths });
+            fs.writeFileSync(outfile, result.css);
+        } catch (err) {
+            console.error(`Sass compilation error in ${entry}:`, err);
+        }
     }
 };

--- a/src/_hvac/App.jsx
+++ b/src/_hvac/App.jsx
@@ -1,0 +1,190 @@
+import { useMemo } from 'react';
+
+import { LESSONS } from './data/lessons.js';
+import { DEFAULT_SYSTEM, derive } from './lib/derive.js';
+import { useHashRoute } from './hooks/useHashRoute.js';
+import { usePersistentState } from './hooks/usePersistentState.js';
+
+import { Prose } from './components/Prose.jsx';
+import { AirflowPlanner } from './calculators/AirflowPlanner.jsx';
+import { DuctSizer } from './calculators/DuctSizer.jsx';
+import { EffectiveLength } from './calculators/EffectiveLength.jsx';
+import { PressureBudget } from './calculators/PressureBudget.jsx';
+import { ReturnSizer } from './calculators/ReturnSizer.jsx';
+import { Quiz } from './views/Quiz.jsx';
+import { Secrets } from './views/Secrets.jsx';
+
+/*
+The shell: navigation, the persistent worksheet strip, and one
+view at a time. Lessons come from data, calculators come from
+this registry, and the two reference views are appended at the
+end — so there is exactly one list of views in the app.
+*/
+
+const CALCULATORS = { AirflowPlanner, PressureBudget, EffectiveLength, DuctSizer, ReturnSizer };
+
+const REFERENCE_VIEWS = [
+    {
+        id: 'secrets',
+        nav: 'Expert secrets',
+        title: 'Everything the pros know and rarely say',
+        subtitle: 'The full cheat sheet, grouped so you can find it fast with one hand.',
+        view: Secrets,
+    },
+    {
+        id: 'quiz',
+        nav: 'Check yourself',
+        title: 'Ten questions',
+        subtitle: 'Each one targets a mistake that shows up in real installs. Wrong answers teach more than right ones.',
+        view: Quiz,
+    },
+];
+
+const VIEWS = [...LESSONS, ...REFERENCE_VIEWS];
+const findView = (id) => VIEWS.find((view) => view.id === id) ?? VIEWS[0];
+
+function WorksheetStrip({ derived, onReset }) {
+    const items = [
+        { label: 'Airflow', value: `${derived.totalCfm.toLocaleString()} CFM` },
+        { label: 'Available pressure', value: `${derived.available.toFixed(2)} in.wc` },
+        { label: 'Effective length', value: `${derived.tel.total} ft` },
+        { label: 'Friction rate', value: derived.rate.toFixed(3) },
+    ];
+
+    return (
+        <div className={`worksheet worksheet--${derived.rateGrade.level}`}>
+            <p className="worksheet__title">Your worksheet</p>
+            <dl>
+                {items.map((item) => (
+                    <div key={item.label}>
+                        <dt>{item.label}</dt>
+                        <dd>{item.value}</dd>
+                    </div>
+                ))}
+            </dl>
+            <button type="button" className="button button--quiet" onClick={onReset}>
+                Reset
+            </button>
+        </div>
+    );
+}
+
+function Nav({ current, navigate }) {
+    const groups = [
+        { title: 'Orientation', ids: ['start', 'basics'] },
+        { title: 'The eight steps', ids: LESSONS.filter((lesson) => lesson.step > 0).map((lesson) => lesson.id) },
+        { title: 'Reference', ids: REFERENCE_VIEWS.map((view) => view.id) },
+    ];
+
+    return (
+        <nav className="nav" aria-label="Lessons">
+            {groups.map((group) => (
+                <div key={group.title} className="nav__group">
+                    <p className="nav__title">{group.title}</p>
+                    <ul>
+                        {group.ids.map((id) => {
+                            const view = findView(id);
+                            return (
+                                <li key={id}>
+                                    <button
+                                        type="button"
+                                        className={id === current ? 'nav__link nav__link--active' : 'nav__link'}
+                                        aria-current={id === current ? 'page' : undefined}
+                                        onClick={() => navigate(id)}
+                                    >
+                                        {view.nav}
+                                    </button>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </div>
+            ))}
+        </nav>
+    );
+}
+
+function Pager({ current, navigate }) {
+    const index = VIEWS.findIndex((view) => view.id === current);
+    const previous = VIEWS[index - 1];
+    const next = VIEWS[index + 1];
+
+    return (
+        <div className="pager">
+            {previous ? (
+                <button type="button" className="button button--quiet" onClick={() => navigate(previous.id)}>
+                    ← {previous.nav}
+                </button>
+            ) : (
+                <span />
+            )}
+            {next && (
+                <button type="button" className="button" onClick={() => navigate(next.id)}>
+                    {next.nav} →
+                </button>
+            )}
+        </div>
+    );
+}
+
+export default function App() {
+    const [route, navigate] = useHashRoute('start');
+    const [system, setSystem, resetSystem] = usePersistentState('hvac-worksheet', DEFAULT_SYSTEM);
+
+    const derived = useMemo(() => derive(system), [system]);
+    const update = (patch) => setSystem((current) => ({ ...current, ...patch }));
+
+    const view = findView(route);
+    const Calculator = view.calculator ? CALCULATORS[view.calculator] : null;
+    const View = view.view ?? null;
+
+    return (
+        <div className="app">
+            <header className="masthead">
+                <div>
+                    <p className="masthead__eyebrow">Learn by doing</p>
+                    <h1>Duct Sizing for DIYers</h1>
+                    <p className="masthead__tagline">
+                        The real method professionals use, with the shortcuts they never write down. Work through the eight steps and the app builds
+                        your duct schedule as you go.
+                    </p>
+                </div>
+                <a className="masthead__home" href="/">
+                    ← derekonay.com
+                </a>
+            </header>
+
+            <div className="layout">
+                <aside className="layout__nav">
+                    <Nav current={view.id} navigate={navigate} />
+                </aside>
+
+                <main className="layout__main">
+                    <WorksheetStrip derived={derived} onReset={resetSystem} />
+
+                    <article className="lesson">
+                        <header className="lesson__header">
+                            {view.step > 0 && <p className="lesson__step">Step {view.step} of 8</p>}
+                            <h2>{view.title}</h2>
+                            <p className="lesson__subtitle">{view.subtitle}</p>
+                        </header>
+
+                        {view.blocks && <Prose blocks={view.blocks} />}
+                        {Calculator && <Calculator system={system} update={update} derived={derived} />}
+                        {View && <View />}
+                    </article>
+
+                    <Pager current={view.id} navigate={navigate} />
+                </main>
+            </div>
+
+            <footer className="site-footer">
+                <p>
+                    Built as a teaching tool. Every number comes from the standard duct friction and equivalent-diameter equations, with fitting
+                    losses in the spirit of ACCA Manual D. It is not a substitute for a stamped Manual J/S/D report, which your permit and your
+                    equipment warranty may require.
+                </p>
+            </footer>
+        </div>
+    );
+}

--- a/src/_hvac/README.md
+++ b/src/_hvac/README.md
@@ -62,11 +62,13 @@ and restoring the page later is just putting that one file back.
 
 ### Option 2 — revert the commits (cleanest full removal)
 
-Every commit that added this applet touched this directory, so ask git for the list
-rather than trusting a hash written down here:
+Ask git for the commits rather than trusting a hash written down here. Search by
+message, **not** by path — one of them only touched `.eleventy.js`, so
+`git log -- src/_hvac` misses it and leaves behind a watch target pointing at the
+directory you just deleted:
 
 ```bash
-git log --oneline -- src/_hvac          # newest first
+git log --oneline -i --grep=hvac        # newest first
 ```
 
 Then revert them, **newest first**, and reinstall:

--- a/src/_hvac/README.md
+++ b/src/_hvac/README.md
@@ -1,0 +1,114 @@
+# `/hvac` — Duct Sizing for DIYers
+
+A self-contained React applet that teaches an amateur DIYer how to size and install
+HVAC ductwork. It lives on its own route at **`/hvac`** and shares nothing with the
+rest of the site except the web fonts.
+
+```bash
+npm start      # dev server with hot reload -> http://localhost:8080/hvac/
+npm test       # 17 unit tests for the duct math
+npm run build  # production build into public/
+```
+
+## Layout
+
+| Path | What it is |
+| --- | --- |
+| `index.jsx` | Mounts `App` into `#hvac-root` |
+| `App.jsx` | Shell: nav, worksheet strip, one view at a time |
+| `lib/ductMath.js` | Every calculation in the app. Pure functions |
+| `lib/ductMath.test.js` | Checks the math against published reference values |
+| `lib/fittings.js` | Fitting equivalent-length data and total effective length |
+| `lib/derive.js` | Turns the worksheet into results, in one place |
+| `data/lessons.js` | Lesson content as block lists |
+| `data/secrets.js` | The expert-secrets cheat sheet |
+| `data/quiz.js` | Self-check questions |
+| `components/` | `Prose` renders lesson blocks; `Field` and `Results` are the UI primitives |
+| `calculators/` | One component per step that has a worksheet |
+| `views/` | The two reference screens (secrets, quiz) |
+| `styles.scss` | The applet's entire stylesheet |
+
+Two conventions worth keeping if you extend it: lesson content is **data, not markup**
+(a new block type is a three-line addition to `components/Prose.jsx`), and all
+arithmetic stays in `lib/` so it can be unit tested without a browser.
+
+## How it hooks into the site
+
+The applet touches the rest of the project in exactly **three** places. This is the
+whole integration surface, and the list you need in order to remove it.
+
+1. **`src/hvac.njk`** — the page. Front matter only; it sets `permalink: /hvac/index.html`.
+2. **`src/_layouts/hvac.njk`** — a minimal layout that loads `hvac.css` and `hvac.js`
+   instead of the site bundle.
+3. **`src/_11ty/build-assets.js`** — lists `src/_hvac/index.jsx` and `styles.scss` as
+   esbuild and Sass entry points, so they compile to `public/assets/{js,css}/hvac.*`.
+
+Plus two housekeeping edits. `.eleventy.js` gains two lines — one so `npm start`
+rebuilds when you edit this directory, one so this README does not publish itself as a
+page (markdown is a template format, and this directory sits inside Eleventy's input
+dir). And `package.json` adds `react`, `react-dom`, and a real `test` script.
+
+## Removing it
+
+### Option 1 — take the page down, keep the code
+
+```bash
+rm src/hvac.njk
+npm run build
+```
+
+The route is gone. Nothing else needs touching — the applet source stays in the repo,
+and restoring the page later is just putting that one file back.
+
+### Option 2 — revert the commits (cleanest full removal)
+
+Every commit that added this applet touched this directory, so ask git for the list
+rather than trusting a hash written down here:
+
+```bash
+git log --oneline -- src/_hvac          # newest first
+```
+
+Then revert them, **newest first**, and reinstall:
+
+```bash
+git revert --no-commit <newest> <...> <oldest>
+git commit -m "Remove the /hvac duct sizing applet"
+npm install
+```
+
+If the work was squash-merged, that log shows a single commit and you revert just it.
+
+### Option 3 — remove it by hand
+
+```bash
+# 1. Delete the applet and its two page files
+rm -rf src/_hvac src/_layouts/hvac.njk src/hvac.njk
+
+# 2. Restore the original single-entry asset builder
+git checkout 8e6022f -- src/_11ty/build-assets.js
+
+# 3. Drop the dependencies
+npm uninstall react react-dom
+```
+
+Then delete the two `src/_hvac` lines from `.eleventy.js` (the `addWatchTarget` call and
+the `ignores.add` call), and the `🌬️ The /hvac applet` section from the root
+`README.md`. If you want the old placeholder `test` script back, set it to
+`echo "Error: no test specified" && exit 1` in `package.json`.
+
+Finally, `npm run build`. It begins with `rimraf public`, so the generated
+`hvac.js` and `hvac.css` disappear on their own — there is nothing stale to clean up.
+
+## Notes
+
+- Reverting `build-assets.js` in Option 3 also reverts it for the main site bundle.
+  That is intentional: `8e6022f` is the last commit before this applet existed, and the
+  file's only other change was being generalised from one hardcoded pair of entry points
+  to a list.
+- The worksheet persists in `localStorage` under the key `hvac-worksheet`. Removing the
+  applet leaves that key behind in the browsers of anyone who used it; it is inert.
+- The math is deliberately honest about its simplifications — the room-by-room split is
+  area weighted by exposure, not a Manual J load calculation, and fitting losses are
+  representative values in the spirit of ACCA Manual D. Both caveats are stated in the
+  UI. Keep them there if you edit the content.

--- a/src/_hvac/calculators/AirflowPlanner.jsx
+++ b/src/_hvac/calculators/AirflowPlanner.jsx
@@ -1,0 +1,115 @@
+import { CFM_PER_TON_PRESETS, EXPOSURE_FACTORS } from '../lib/ductMath.js';
+import { Fields, NumberField, SelectField, TextField } from '../components/Field.jsx';
+import { Panel, Stat, StatRow } from '../components/Results.jsx';
+
+/*
+Step 1 worksheet: total airflow, then the room-by-room split.
+Everything downstream reads these numbers.
+*/
+
+let roomCounter = 0;
+
+export function AirflowPlanner({ system, update, derived }) {
+    const updateRoom = (id, patch) =>
+        update({ rooms: system.rooms.map((room) => (room.id === id ? { ...room, ...patch } : room)) });
+
+    const addRoom = () =>
+        update({ rooms: [...system.rooms, { id: `room-new-${roomCounter++}`, name: 'New room', area: 120, exposure: 1.15 }] });
+
+    const removeRoom = (id) => update({ rooms: system.rooms.filter((room) => room.id !== id) });
+
+    return (
+        <>
+            <Panel title="Total system airflow" description="Start from the equipment you have, or the equipment a load calculation told you to buy.">
+                <Fields>
+                    <NumberField
+                        label="System capacity"
+                        value={system.tons}
+                        onChange={(tons) => update({ tons })}
+                        suffix="tons"
+                        step={0.5}
+                        min={0.5}
+                        max={10}
+                        hint="12,000 BTU/h per ton"
+                    />
+                    <SelectField
+                        label="Airflow per ton"
+                        value={String(system.cfmPerTon)}
+                        onChange={(value) => update({ cfmPerTon: Number(value) })}
+                        options={CFM_PER_TON_PRESETS.map((preset) => ({ value: String(preset.value), label: preset.label }))}
+                    />
+                </Fields>
+
+                <StatRow>
+                    <Stat label="Total airflow" value={derived.totalCfm.toLocaleString()} unit="CFM" tone="primary" />
+                    <Stat label="Rooms on the plan" value={system.rooms.length} />
+                    <Stat
+                        label="Largest single room"
+                        value={derived.largestRoomCfm}
+                        unit="CFM"
+                        tone={derived.largestRoomCfm > 400 ? 'warn' : 'neutral'}
+                        hint={derived.largestRoomCfm > 400 ? 'Over 400 — split it into two branches' : 'Fits on one branch'}
+                    />
+                </StatRow>
+            </Panel>
+
+            <Panel
+                title="Room-by-room split"
+                description="Area weighted by exposure. A stand-in for a room-by-room Manual J, close enough to buy the right fittings."
+                footnote="Shares are relative, so the airflows always add up to the system total no matter what you type."
+            >
+                <div className="table-scroll">
+                    <table className="room-table">
+                        <thead>
+                            <tr>
+                                <th>Room</th>
+                                <th>Floor area</th>
+                                <th>Exposure</th>
+                                <th className="numeric">Share</th>
+                                <th className="numeric">Airflow</th>
+                                <th aria-label="Remove" />
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {derived.rooms.map((room) => (
+                                <tr key={room.id}>
+                                    <td>
+                                        <TextField label="" value={room.name} onChange={(name) => updateRoom(room.id, { name })} />
+                                    </td>
+                                    <td>
+                                        <NumberField
+                                            label=""
+                                            value={room.area}
+                                            onChange={(area) => updateRoom(room.id, { area: Number(area) || 0 })}
+                                            suffix="ft²"
+                                            step={10}
+                                        />
+                                    </td>
+                                    <td>
+                                        <SelectField
+                                            label=""
+                                            value={String(room.exposure)}
+                                            onChange={(value) => updateRoom(room.id, { exposure: Number(value) })}
+                                            options={EXPOSURE_FACTORS.map((factor) => ({ value: String(factor.value), label: factor.label }))}
+                                        />
+                                    </td>
+                                    <td className="numeric">{Math.round(room.share * 100)}%</td>
+                                    <td className="numeric strong">{room.cfm} CFM</td>
+                                    <td>
+                                        <button type="button" className="button button--quiet" onClick={() => removeRoom(room.id)} aria-label={`Remove ${room.name}`}>
+                                            ×
+                                        </button>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+
+                <button type="button" className="button" onClick={addRoom}>
+                    Add a room
+                </button>
+            </Panel>
+        </>
+    );
+}

--- a/src/_hvac/calculators/DuctSizer.jsx
+++ b/src/_hvac/calculators/DuctSizer.jsx
@@ -1,0 +1,243 @@
+import { useState } from 'react';
+
+import {
+    MATERIALS,
+    ROUND_SIZES,
+    VELOCITY_LIMITS,
+    cfmAtSize,
+    gradeAspectRatio,
+    gradeVelocity,
+    nextRoundSize,
+    rectangularOptions,
+    requiredDiameter,
+    roundVelocity,
+} from '../lib/ductMath.js';
+
+import { Fields, NumberField, SelectField } from '../components/Field.jsx';
+import { Panel, Stat, StatRow, Verdict } from '../components/Results.jsx';
+
+/*
+Step 4 worksheet, in three parts:
+
+  1. Size one duct, and see why.
+  2. A schedule for the whole house, generated from the rooms
+     entered in Step 1 — this is the sheet you take shopping.
+  3. A ductulator table, computed rather than pasted, so you
+     can look sizes up without the app.
+*/
+
+const REFERENCE_RATES = [0.06, 0.08, 0.1, 0.12, 0.15];
+
+const ROLE_OPTIONS = Object.entries(VELOCITY_LIMITS).map(([value, limit]) => ({
+    value,
+    label: `${limit.label} (${limit.min}–${limit.max} fpm)`,
+}));
+
+function SingleDuct({ defaultCfm, rate, materialFactor }) {
+    const [cfm, setCfm] = useState(defaultCfm);
+    const [role, setRole] = useState('supplyBranch');
+
+    const exactDiameter = requiredDiameter(cfm, rate, materialFactor);
+    const nominal = nextRoundSize(exactDiameter);
+    const velocity = roundVelocity(cfm, nominal);
+    const rects = rectangularOptions(exactDiameter, cfm);
+    const noise = gradeVelocity(velocity, role);
+
+    return (
+        <Panel
+            title="Size one duct"
+            description="Airflow plus the friction rate from Step 3. Round up to a size you can buy, then check the velocity."
+            footnote="Rectangular options are matched by equivalent diameter — the round pipe that loses the same pressure per foot."
+        >
+            <Fields>
+                <NumberField label="Airflow through this duct" value={cfm} onChange={setCfm} suffix="CFM" step={25} min={10} />
+                <SelectField label="What is this duct" value={role} onChange={setRole} options={ROLE_OPTIONS} />
+            </Fields>
+
+            <StatRow>
+                <Stat label="Calculated diameter" value={exactDiameter.toFixed(1)} unit="in" hint="What the equation asks for" />
+                <Stat label="Install this" value={nominal} unit="in round" tone="primary" hint="Next size up. Never round down." />
+                <Stat label="Velocity at that size" value={Math.round(velocity).toLocaleString()} unit="fpm" tone={noise.level} />
+            </StatRow>
+
+            <Verdict grade={noise} prefix="Noise check:" />
+
+            <h4 className="panel__subhead">If a cavity forces rectangular</h4>
+            <div className="table-scroll">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Size</th>
+                            <th className="numeric">Aspect ratio</th>
+                            <th className="numeric">Velocity</th>
+                            <th>Verdict</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rects.map((option) => {
+                            const grade = gradeAspectRatio(option.aspectRatio);
+                            return (
+                                <tr key={`${option.width}x${option.depth}`}>
+                                    <td className="strong">
+                                        {option.width}" × {option.depth}"
+                                    </td>
+                                    <td className="numeric">{option.aspectRatio.toFixed(1)}:1</td>
+                                    <td className="numeric">{Math.round(option.velocity).toLocaleString()} fpm</td>
+                                    <td className={`cell--${grade.level}`}>{grade.message}</td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            </div>
+        </Panel>
+    );
+}
+
+function Schedule({ rooms, totalCfm, rate, materialFactor }) {
+    const trunkDiameter = requiredDiameter(totalCfm, rate, materialFactor);
+    const trunkNominal = nextRoundSize(trunkDiameter);
+
+    const rows = [
+        {
+            key: 'trunk',
+            name: 'Supply trunk (at the plenum)',
+            cfm: totalCfm,
+            role: 'supplyTrunk',
+            diameter: trunkDiameter,
+            nominal: trunkNominal,
+        },
+        ...rooms.map((room) => {
+            const diameter = requiredDiameter(room.cfm, rate, materialFactor);
+            return {
+                key: room.id,
+                name: room.name,
+                cfm: room.cfm,
+                role: 'supplyBranch',
+                diameter,
+                nominal: nextRoundSize(diameter),
+            };
+        }),
+    ];
+
+    return (
+        <Panel
+            title="Your duct schedule"
+            description="Generated from the rooms in Step 1 at your friction rate. This is the list you take to the supply house."
+            footnote="Branches over 400 CFM should be split into two runs. Size the trunk sections as air peels off — see Step 6."
+        >
+            <div className="table-scroll">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Run</th>
+                            <th className="numeric">Airflow</th>
+                            <th className="numeric">Calculated</th>
+                            <th className="numeric">Buy</th>
+                            <th className="numeric">Velocity</th>
+                            <th>Check</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rows.map((row) => {
+                            const velocity = roundVelocity(row.cfm, row.nominal);
+                            const grade = gradeVelocity(velocity, row.role);
+                            return (
+                                <tr key={row.key}>
+                                    <td>{row.name}</td>
+                                    <td className="numeric">{row.cfm} CFM</td>
+                                    <td className="numeric muted">{row.diameter.toFixed(1)}"</td>
+                                    <td className="numeric strong">{row.nominal}" round</td>
+                                    <td className="numeric">{Math.round(velocity).toLocaleString()} fpm</td>
+                                    <td className={`cell--${grade.level}`}>{grade.level === 'good' ? 'Good' : grade.message}</td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            </div>
+        </Panel>
+    );
+}
+
+function ReferenceTable({ materialFactor }) {
+    return (
+        <Panel
+            title="Pocket ductulator"
+            description="Maximum airflow for round duct, computed from the friction equation. Read down your friction rate column."
+            footnote="Values shown for the material selected above. Rigid metal is the baseline every published chart assumes."
+        >
+            <div className="table-scroll">
+                <table className="reference">
+                    <thead>
+                        <tr>
+                            <th>Round size</th>
+                            {REFERENCE_RATES.map((rate) => (
+                                <th key={rate} className="numeric">
+                                    {rate.toFixed(2)}
+                                </th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {ROUND_SIZES.map((size) => (
+                            <tr key={size}>
+                                <td className="strong">{size}"</td>
+                                {REFERENCE_RATES.map((rate) => (
+                                    <td key={rate} className="numeric">
+                                        {Math.round(cfmAtSize(size, rate, materialFactor))}
+                                    </td>
+                                ))}
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+            <p className="panel__footnote">Columns are friction rate in in.wc per 100 ft. Cells are CFM.</p>
+        </Panel>
+    );
+}
+
+export function DuctSizer({ system, update, derived }) {
+    const [rateOverride, setRateOverride] = useState(null);
+    const rate = rateOverride ?? derived.rate;
+
+    return (
+        <>
+            <Panel
+                title="Design inputs"
+                description="Carried forward from Steps 1 through 3. Override the friction rate here if you want to explore."
+            >
+                <Fields>
+                    <NumberField
+                        label="Friction rate"
+                        value={Number(rate.toFixed(3))}
+                        onChange={(value) => setRateOverride(Number(value) || 0.0001)}
+                        suffix="in.wc/100ft"
+                        step={0.01}
+                        min={0.01}
+                        max={0.5}
+                        hint={rateOverride === null ? 'From your worksheet' : 'Overridden — clear to go back'}
+                    />
+                    <SelectField
+                        label="Duct material"
+                        value={system.material}
+                        onChange={(material) => update({ material })}
+                        options={Object.entries(MATERIALS).map(([value, item]) => ({ value, label: `${item.label} — ${item.factor}× friction` }))}
+                        hint={derived.material.note}
+                    />
+                </Fields>
+                {rateOverride !== null && (
+                    <button type="button" className="button button--quiet" onClick={() => setRateOverride(null)}>
+                        Use my worksheet rate ({derived.rate.toFixed(3)})
+                    </button>
+                )}
+                <Verdict grade={derived.rateGrade} prefix="Worksheet rate:" />
+            </Panel>
+
+            <SingleDuct defaultCfm={Math.max(75, derived.largestRoomCfm)} rate={rate} materialFactor={derived.materialFactor} />
+            <Schedule rooms={derived.rooms} totalCfm={derived.totalCfm} rate={rate} materialFactor={derived.materialFactor} />
+            <ReferenceTable materialFactor={derived.materialFactor} />
+        </>
+    );
+}

--- a/src/_hvac/calculators/EffectiveLength.jsx
+++ b/src/_hvac/calculators/EffectiveLength.jsx
@@ -1,0 +1,99 @@
+import { FITTING_GROUPS } from '../lib/fittings.js';
+import { Fields, NumberField } from '../components/Field.jsx';
+import { Panel, Stat, StatRow, Verdict } from '../components/Results.jsx';
+
+/*
+Step 3 worksheet. Counting fittings is the part beginners skip,
+so the equivalent-length price tag sits right next to every
+stepper — the lesson lands faster when you watch 45 feet appear
+because you added one plain rectangular elbow.
+*/
+
+function FittingCounter({ fitting, count, onChange }) {
+    return (
+        <div className="fitting">
+            <div className="fitting__info">
+                <p className="fitting__label">{fitting.label}</p>
+                <p className="fitting__cost">{fitting.ef} equivalent ft each</p>
+            </div>
+            <div className="stepper">
+                <button type="button" onClick={() => onChange(Math.max(0, count - 1))} aria-label={`One fewer ${fitting.label}`}>
+                    −
+                </button>
+                <span className={count > 0 ? 'stepper__count stepper__count--active' : 'stepper__count'}>{count}</span>
+                <button type="button" onClick={() => onChange(count + 1)} aria-label={`One more ${fitting.label}`}>
+                    +
+                </button>
+            </div>
+            <p className="fitting__total">{count > 0 ? `${count * fitting.ef} ft` : '—'}</p>
+        </div>
+    );
+}
+
+export function EffectiveLength({ system, update, derived }) {
+    const setCount = (id, count) => update({ fittings: { ...system.fittings, [id]: count } });
+
+    return (
+        <>
+            <Panel
+                title="Measured length of the worst path"
+                description="Tape-measure feet along the single longest supply run, and the single longest return run. Not the whole house."
+            >
+                <Fields>
+                    <NumberField
+                        label="Longest supply run"
+                        value={system.supplyRun}
+                        onChange={(supplyRun) => update({ supplyRun })}
+                        suffix="ft"
+                        step={5}
+                        hint="Plenum → trunk → branch → register"
+                    />
+                    <NumberField
+                        label="Longest return run"
+                        value={system.returnRun}
+                        onChange={(returnRun) => update({ returnRun })}
+                        suffix="ft"
+                        step={5}
+                        hint="Grille → return duct → air handler"
+                    />
+                </Fields>
+            </Panel>
+
+            <Panel
+                title="Fittings on that path"
+                description="Count only the fittings the air passes through on the one path you measured above."
+                footnote="Representative values in the spirit of ACCA Manual D Appendix 3. Use the published tables for permit drawings."
+            >
+                {FITTING_GROUPS.map((group) => (
+                    <div key={group.id} className="fitting-group">
+                        <h4>{group.title}</h4>
+                        {group.fittings.map((fitting) => (
+                            <FittingCounter
+                                key={fitting.id}
+                                fitting={fitting}
+                                count={system.fittings[fitting.id] ?? 0}
+                                onChange={(count) => setCount(fitting.id, count)}
+                            />
+                        ))}
+                    </div>
+                ))}
+            </Panel>
+
+            <Panel title="Your friction rate" description="This one number sizes every duct in the building.">
+                <StatRow>
+                    <Stat label="Measured duct" value={derived.tel.measured} unit="ft" />
+                    <Stat
+                        label="Fittings"
+                        value={derived.tel.fittings}
+                        unit="equiv. ft"
+                        tone={derived.tel.fittings > derived.tel.measured ? 'warn' : 'neutral'}
+                        hint={derived.tel.fittings > derived.tel.measured ? 'Fittings cost more than your straight duct' : undefined}
+                    />
+                    <Stat label="Total effective length" value={derived.tel.total} unit="ft" />
+                    <Stat label="Friction rate" value={derived.rate.toFixed(3)} unit="in.wc/100ft" tone="primary" />
+                </StatRow>
+                <Verdict grade={derived.rateGrade} />
+            </Panel>
+        </>
+    );
+}

--- a/src/_hvac/calculators/PressureBudget.jsx
+++ b/src/_hvac/calculators/PressureBudget.jsx
@@ -1,0 +1,99 @@
+import { COMPONENT_DROPS } from '../lib/ductMath.js';
+import { Fields, NumberField } from '../components/Field.jsx';
+import { Panel, Stat, StatRow } from '../components/Results.jsx';
+
+/*
+Step 2 worksheet. Deliberately shows the arithmetic as a
+running ledger — the point of the lesson is that the budget
+is small and everything in the airstream spends it.
+*/
+
+const BLOWER_PRESETS = [
+    { label: 'Older PSC furnace', value: 0.5 },
+    { label: 'Typical ECM air handler', value: 0.7 },
+    { label: 'High-static ECM', value: 0.9 },
+];
+
+export function PressureBudget({ system, update, derived }) {
+    const setDrop = (id, value) => update({ drops: { ...system.drops, [id]: Number(value) || 0 } });
+
+    const tone = derived.available <= 0 ? 'bad' : derived.available < 0.15 ? 'warn' : 'primary';
+
+    return (
+        <>
+            <Panel
+                title="What the blower is rated for"
+                description="From the blower performance table in your equipment manual, at the airflow and speed tap you plan to run."
+            >
+                <Fields columns={1}>
+                    <NumberField
+                        label="Rated external static pressure"
+                        value={system.blowerEsp}
+                        onChange={(blowerEsp) => update({ blowerEsp })}
+                        suffix="in.wc"
+                        step={0.05}
+                        min={0.1}
+                        max={2}
+                        hint={`Typical: ${BLOWER_PRESETS.map((preset) => `${preset.label} ${preset.value}`).join(' · ')}`}
+                    />
+                </Fields>
+            </Panel>
+
+            <Panel
+                title="Everything that takes a bite"
+                description="Use manufacturer numbers where you have them. The typical values are starting points, not answers."
+                footnote="Set a component to 0 if your blower table already includes it — double-counting the coil is the classic mistake."
+            >
+                <div className="table-scroll">
+                    <table className="ledger">
+                        <thead>
+                            <tr>
+                                <th>Component</th>
+                                <th>Typical</th>
+                                <th>Yours</th>
+                                <th>Note</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {COMPONENT_DROPS.map((component) => (
+                                <tr key={component.id}>
+                                    <td>{component.label}</td>
+                                    <td className="numeric muted">{component.typical.toFixed(2)}</td>
+                                    <td>
+                                        <NumberField
+                                            label=""
+                                            value={system.drops[component.id] ?? 0}
+                                            onChange={(value) => setDrop(component.id, value)}
+                                            step={0.01}
+                                            min={0}
+                                            max={1}
+                                        />
+                                    </td>
+                                    <td className="muted small">{component.hint}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+
+                <StatRow>
+                    <Stat label="Blower rating" value={system.blowerEsp.toFixed(2)} unit="in.wc" />
+                    <Stat label="Spent on components" value={`−${derived.spent.toFixed(2)}`} unit="in.wc" tone="warn" />
+                    <Stat
+                        label="Available for ducts"
+                        value={derived.available.toFixed(2)}
+                        unit="in.wc"
+                        tone={tone}
+                        hint={
+                            derived.available <= 0
+                                ? 'Nothing left. Fix this upstream — bigger filter, better coil, stronger blower.'
+                                : derived.available < 0.15
+                                  ? 'Tight. Expect large ducts on any long run.'
+                                  : 'Healthy budget to design against.'
+                        }
+                    />
+                </StatRow>
+            </Panel>
+        </>
+    );
+}

--- a/src/_hvac/calculators/ReturnSizer.jsx
+++ b/src/_hvac/calculators/ReturnSizer.jsx
@@ -1,0 +1,137 @@
+import { useState } from 'react';
+
+import { GRILLE_TYPES, gradeVelocity, requiredGrilleFaceArea, returnPlan, roundVelocity } from '../lib/ductMath.js';
+import { Fields, NumberField, SelectField } from '../components/Field.jsx';
+import { Panel, Stat, StatRow, Verdict } from '../components/Results.jsx';
+
+/*
+Step 5 worksheet. The return path carries the entire blower
+airflow, so this screen starts from total CFM and never from a
+single room — that framing is the lesson.
+*/
+
+const FACE_VELOCITIES = [
+    { value: 300, label: '300 fpm — whisper quiet, largest grille' },
+    { value: 400, label: '400 fpm — the standard target' },
+    { value: 500, label: '500 fpm — the practical maximum' },
+    { value: 600, label: '600 fpm — you will hear this' },
+];
+
+export function ReturnSizer({ derived }) {
+    const [faceVelocity, setFaceVelocity] = useState(400);
+    const [grilleType, setGrilleType] = useState('stamped');
+    const [grilleCount, setGrilleCount] = useState(2);
+
+    const plan = returnPlan(derived.totalCfm, {
+        faceVelocity,
+        grilleType,
+        materialFactor: derived.materialFactor,
+        rate: derived.rate,
+    });
+
+    const cfmPerGrille = derived.totalCfm / Math.max(1, grilleCount);
+    const perGrilleFace = requiredGrilleFaceArea(cfmPerGrille, faceVelocity, GRILLE_TYPES[grilleType].freeArea);
+    const perGrilleSide = Math.ceil(Math.sqrt(perGrilleFace) / 2) * 2;
+
+    const upsized = plan.nominalDuct + 2;
+    const ductVelocity = roundVelocity(derived.totalCfm, plan.nominalDuct);
+    const upsizedVelocity = roundVelocity(derived.totalCfm, upsized);
+
+    return (
+        <>
+            <Panel
+                title="The return has to carry everything"
+                description="Not one room's worth. The full blower airflow, at a lower velocity than the supply side."
+            >
+                <Fields>
+                    <SelectField
+                        label="Target face velocity"
+                        value={String(faceVelocity)}
+                        onChange={(value) => setFaceVelocity(Number(value))}
+                        options={FACE_VELOCITIES.map((item) => ({ value: String(item.value), label: item.label }))}
+                        hint="Velocity through the grille's free area, not its outside dimensions"
+                    />
+                    <SelectField
+                        label="Grille style"
+                        value={grilleType}
+                        onChange={setGrilleType}
+                        options={Object.entries(GRILLE_TYPES).map(([value, item]) => ({
+                            value,
+                            label: `${item.label} — ${Math.round(item.freeArea * 100)}% free area`,
+                        }))}
+                    />
+                </Fields>
+
+                <StatRow>
+                    <Stat label="System airflow" value={derived.totalCfm.toLocaleString()} unit="CFM" />
+                    <Stat label="Net free area needed" value={(plan.faceAreaSqFt * GRILLE_TYPES[grilleType].freeArea).toFixed(1)} unit="ft²" />
+                    <Stat label="Total grille face needed" value={plan.faceAreaSqFt.toFixed(1)} unit="ft²" tone="primary" />
+                </StatRow>
+            </Panel>
+
+            <Panel
+                title="How many grilles"
+                description="Splitting the return between two or three grilles is quieter, cheaper to fabricate, and pulls air more evenly from the house."
+                footnote="Put them in central spaces — hallways and living areas. Keep them away from supply registers."
+            >
+                <Fields columns={1}>
+                    <NumberField
+                        label="Number of return grilles"
+                        value={grilleCount}
+                        onChange={(value) => setGrilleCount(Math.max(1, Number(value) || 1))}
+                        step={1}
+                        min={1}
+                        max={6}
+                    />
+                </Fields>
+
+                <StatRow>
+                    <Stat label="Airflow per grille" value={Math.round(cfmPerGrille)} unit="CFM" />
+                    <Stat
+                        label="Each grille, roughly"
+                        value={`${perGrilleSide}" × ${perGrilleSide}"`}
+                        tone="primary"
+                        hint="Or any rectangle with the same face area"
+                    />
+                    <Stat
+                        label="One grille instead"
+                        value={`${plan.singleGrille}" × ${plan.singleGrille}"`}
+                        tone={plan.singleGrille > 24 ? 'warn' : 'neutral'}
+                        hint={plan.singleGrille > 24 ? 'Awkwardly large — split it' : 'Manageable as a single grille'}
+                    />
+                </StatRow>
+            </Panel>
+
+            <Panel
+                title="Return duct size"
+                description="Sized at your friction rate for the full airflow — then upsized, because return duct is the cheapest insurance in HVAC."
+            >
+                <StatRow>
+                    <Stat label="Calculated" value={plan.ductDiameter.toFixed(1)} unit="in" />
+                    <Stat
+                        label="Minimum to buy"
+                        value={plan.nominalDuct}
+                        unit="in round"
+                        hint={`${Math.round(ductVelocity).toLocaleString()} fpm`}
+                    />
+                    <Stat
+                        label="What to actually install"
+                        value={upsized}
+                        unit="in round"
+                        tone="good"
+                        hint={`${Math.round(upsizedVelocity).toLocaleString()} fpm — quieter, and forgiving of a dirty filter`}
+                    />
+                </StatRow>
+
+                <Verdict grade={gradeVelocity(upsizedVelocity, 'returnTrunk')} prefix="At the upsized diameter:" />
+
+                <h4 className="panel__subhead">Quick sanity check</h4>
+                <p className="panel__note">
+                    One square foot of net free grille area per 400 CFM. At {derived.totalCfm.toLocaleString()} CFM that is about{' '}
+                    <strong>{(derived.totalCfm / 400).toFixed(1)} ft²</strong> of free area. If your grilles do not add up to roughly that, the
+                    return is undersized — and undersized returns cause most of the noise and high static pressure in DIY systems.
+                </p>
+            </Panel>
+        </>
+    );
+}

--- a/src/_hvac/components/Field.jsx
+++ b/src/_hvac/components/Field.jsx
@@ -1,0 +1,72 @@
+/*
+Form primitives. Every calculator input in the app is one of
+these three, which keeps labels, hints, and spacing identical
+everywhere without a CSS framework.
+*/
+
+import { useId } from 'react';
+
+export function NumberField({ label, value, onChange, hint, suffix, step = 1, min = 0, max }) {
+    const id = useId();
+
+    return (
+        <label className="field" htmlFor={id}>
+            <span className="field__label">{label}</span>
+            <span className="field__control">
+                <input
+                    id={id}
+                    type="number"
+                    value={value}
+                    step={step}
+                    min={min}
+                    max={max}
+                    onChange={(event) => onChange(event.target.value === '' ? '' : Number(event.target.value))}
+                />
+                {suffix && <span className="field__suffix">{suffix}</span>}
+            </span>
+            {hint && <span className="field__hint">{hint}</span>}
+        </label>
+    );
+}
+
+export function SelectField({ label, value, onChange, options, hint }) {
+    const id = useId();
+
+    return (
+        <label className="field" htmlFor={id}>
+            <span className="field__label">{label}</span>
+            <span className="field__control">
+                <select id={id} value={value} onChange={(event) => onChange(event.target.value)}>
+                    {options.map((option) => (
+                        <option key={option.value} value={option.value}>
+                            {option.label}
+                        </option>
+                    ))}
+                </select>
+            </span>
+            {hint && <span className="field__hint">{hint}</span>}
+        </label>
+    );
+}
+
+export function TextField({ label, value, onChange, hint }) {
+    const id = useId();
+
+    return (
+        <label className="field" htmlFor={id}>
+            <span className="field__label">{label}</span>
+            <span className="field__control">
+                <input id={id} type="text" value={value} onChange={(event) => onChange(event.target.value)} />
+            </span>
+            {hint && <span className="field__hint">{hint}</span>}
+        </label>
+    );
+}
+
+export function Fields({ children, columns = 2 }) {
+    return (
+        <div className="fields" data-columns={columns}>
+            {children}
+        </div>
+    );
+}

--- a/src/_hvac/components/Prose.jsx
+++ b/src/_hvac/components/Prose.jsx
@@ -1,0 +1,117 @@
+/*
+Renders the lesson block list from data/lessons.js.
+
+One block type, one small function, one entry in the RENDERERS
+map. Adding a block type is a three-line change and no lesson
+ever contains raw HTML.
+*/
+
+/* The only inline markup is **bold**. Splitting on a capture group
+   gives alternating plain/bold chunks, so odd indexes are bold. */
+function Inline({ text }) {
+    return text.split(/\*\*(.+?)\*\*/g).map((chunk, index) => (index % 2 === 1 ? <strong key={index}>{chunk}</strong> : chunk));
+}
+
+const CALLOUT_LABELS = {
+    secret: 'Expert secret',
+    warn: 'Watch out',
+    tip: 'Pro tip',
+};
+
+function Callout({ kind, title, body }) {
+    return (
+        <aside className={`callout callout--${kind}`}>
+            <p className="callout__kind">{CALLOUT_LABELS[kind]}</p>
+            <p className="callout__title">{title}</p>
+            <p className="callout__body">
+                <Inline text={body} />
+            </p>
+        </aside>
+    );
+}
+
+function Formula({ expression, legend }) {
+    return (
+        <div className="formula">
+            <p className="formula__expression">{expression}</p>
+            <ul className="formula__legend">
+                {legend.map((line) => (
+                    <li key={line}>
+                        <Inline text={line} />
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}
+
+function Table({ head, rows }) {
+    return (
+        <div className="table-scroll">
+            <table>
+                <thead>
+                    <tr>
+                        {head.map((cell) => (
+                            <th key={cell}>{cell}</th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {rows.map((row) => (
+                        <tr key={row.join('|')}>
+                            {row.map((cell, index) => (
+                                <td key={index}>
+                                    <Inline text={cell} />
+                                </td>
+                            ))}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+const RENDERERS = {
+    h: (value) => <h3 className="prose__heading">{value}</h3>,
+    p: (value) => (
+        <p>
+            <Inline text={value} />
+        </p>
+    ),
+    list: (value) => (
+        <ul className="prose__list">
+            {value.map((item) => (
+                <li key={item}>
+                    <Inline text={item} />
+                </li>
+            ))}
+        </ul>
+    ),
+    steps: (value) => (
+        <ol className="prose__steps">
+            {value.map((item) => (
+                <li key={item}>
+                    <Inline text={item} />
+                </li>
+            ))}
+        </ol>
+    ),
+    note: (value) => <Callout {...value} />,
+    formula: (value) => <Formula {...value} />,
+    table: (value) => <Table {...value} />,
+};
+
+export function Prose({ blocks }) {
+    return (
+        <div className="prose">
+            {blocks.map((block, index) => {
+                const [type, value] = Object.entries(block)[0];
+                const render = RENDERERS[type];
+                return render ? <div key={index}>{render(value)}</div> : null;
+            })}
+        </div>
+    );
+}
+
+export { Inline };

--- a/src/_hvac/components/Results.jsx
+++ b/src/_hvac/components/Results.jsx
@@ -1,0 +1,45 @@
+/*
+Output primitives: the big answer, the small answer, and the
+verdict chip that tells you whether the answer is any good.
+Grades come from ductMath as { level, message } objects, so
+the styling stays in one place.
+*/
+
+export function Stat({ label, value, unit, tone = 'neutral', hint }) {
+    return (
+        <div className={`stat stat--${tone}`}>
+            <p className="stat__label">{label}</p>
+            <p className="stat__value">
+                {value}
+                {unit && <span className="stat__unit">{unit}</span>}
+            </p>
+            {hint && <p className="stat__hint">{hint}</p>}
+        </div>
+    );
+}
+
+export function StatRow({ children }) {
+    return <div className="stat-row">{children}</div>;
+}
+
+export function Verdict({ grade, prefix }) {
+    return (
+        <p className={`verdict verdict--${grade.level}`}>
+            {prefix && <strong>{prefix} </strong>}
+            {grade.message}
+        </p>
+    );
+}
+
+export function Panel({ title, description, children, footnote }) {
+    return (
+        <section className="panel">
+            <header className="panel__header">
+                <h3>{title}</h3>
+                {description && <p>{description}</p>}
+            </header>
+            {children}
+            {footnote && <p className="panel__footnote">{footnote}</p>}
+        </section>
+    );
+}

--- a/src/_hvac/data/lessons.js
+++ b/src/_hvac/data/lessons.js
@@ -1,0 +1,633 @@
+/*
+===================================================
+CURRICULUM
+===================================================
+Lessons are data, not markup. Each lesson is a list of
+blocks, and one block type maps to one small component in
+components/Prose.jsx. Adding a lesson means adding an
+object here — no new components, no new routes.
+
+Block types:
+  { p }                     paragraph
+  { h }                     subheading
+  { list }                  bullets
+  { steps }                 numbered list
+  { note: { kind, title, body } }   kind: secret | warn | tip
+  { formula: { expression, legend } }
+  { table: { head, rows } }
+
+Inline **double asterisks** render bold. That is the only
+markup, on purpose.
+*/
+
+export const LESSONS = [
+    /* ------------------------------------------------ */
+    {
+        id: 'start',
+        step: null,
+        nav: 'Start here',
+        title: 'Ductwork, demystified',
+        subtitle: 'Eight steps from a bare basement to a system that is quiet, balanced, and passes inspection.',
+        blocks: [
+            {
+                p: 'Sizing ductwork looks like a trade secret because the people who do it well make it look like guessing. It is not. It is one number — the **friction rate** — followed by a lookup table. This app walks you to that number, then hands you the table.',
+            },
+            { h: 'The whole process in one breath' },
+            {
+                steps: [
+                    'Decide how much air the equipment moves, and how much of it each room deserves.',
+                    'Find out how hard the blower can push, then subtract everything that steals pressure.',
+                    'Measure how far the air has to travel — counting fittings as if they were feet of pipe.',
+                    'Divide the leftover pressure by that distance. That is your friction rate.',
+                    'Look up a duct size for every run at that friction rate. Check the velocity so it stays quiet.',
+                    'Size the returns for the whole blower, because that is what kills most DIY systems.',
+                    'Lay it out with the fewest, gentlest turns you can manage.',
+                    'Build it airtight, then measure it to prove you were right.',
+                ],
+            },
+            {
+                note: {
+                    kind: 'secret',
+                    title: 'The secret hiding in plain sight',
+                    body: 'Professionals are not calculating harder than you. They are calculating **once**, on the longest run, and then reusing that one friction rate for the entire house. Every duct in the building gets sized off the same number.',
+                },
+            },
+            { h: 'What you should have on hand' },
+            {
+                list: [
+                    'The **blower table** from your furnace or air handler manual — the page with CFM at different static pressures. This is the single most important document you own.',
+                    'A floor plan with room dimensions. Graph paper is fine.',
+                    'A tape measure and a willingness to crawl.',
+                    'A **manometer** (a digital dual-port one costs less than a bad service call). You cannot verify any of this without it.',
+                ],
+            },
+            {
+                note: {
+                    kind: 'warn',
+                    title: 'What this app is and is not',
+                    body: 'This teaches you the real method with honest simplifications, and every number it prints comes from the standard equations. It is not a stamped Manual J/D/S report. Many jurisdictions require one for a permit, and your equipment warranty may too. Use this to understand your system, plan it, and check somebody else’s work — then get the load calc done properly before you spend money on equipment.',
+                },
+            },
+        ],
+    },
+
+    /* ------------------------------------------------ */
+    {
+        id: 'basics',
+        step: 0,
+        nav: 'How air moves',
+        title: 'Think in pressure, not pipes',
+        subtitle: 'Four ideas. Everything else in this app is bookkeeping.',
+        blocks: [
+            { h: '1. CFM is the delivery, not the goal' },
+            {
+                p: 'Airflow is measured in **cubic feet per minute**. A room does not need "a vent," it needs a quantity of air proportional to how much heat it gains or loses. Undersize the airflow and no amount of thermostat fiddling fixes that room.',
+            },
+            { h: '2. Static pressure is the fuel, and the tank is tiny' },
+            {
+                p: 'Your blower is rated to overcome a fixed amount of resistance — commonly **0.5 in.wc** on an older PSC blower and **0.7 to 0.8** on a modern ECM. That is inches of water column, and it is a shockingly small budget: 0.5 in.wc is about 1/50th of a PSI. A dirty filter can eat a third of it.',
+            },
+            {
+                note: {
+                    kind: 'tip',
+                    title: 'Why techs obsess over static pressure',
+                    body: 'It is the blood pressure of the system. High static means the blower is straining, airflow is down, the coil is freezing or overheating, and the equipment is dying young. It is measurable in five minutes and it tells you more than any other single reading.',
+                },
+            },
+            { h: '3. Friction rate ties the two together' },
+            {
+                p: 'Air rubbing against duct wall loses pressure at a rate that depends on how fast it is moving and how big the pipe is. Express that loss per 100 feet of duct and you have the **friction rate** — the unit that duct charts are indexed by.',
+            },
+            {
+                formula: {
+                    expression: 'Friction rate = (Available static pressure × 100) ÷ Total effective length',
+                    legend: [
+                        'Available static pressure — what the blower has left after the coil, filter, and grilles take their cut, in in.wc',
+                        'Total effective length — the longest supply run plus the longest return run, with fittings counted as equivalent feet',
+                    ],
+                },
+            },
+            { h: '4. Fittings cost feet, not inches' },
+            {
+                p: 'This is the idea beginners are missing when their system does not work. A sheet metal elbow is 12 inches long and costs the same pressure as **15 feet** of straight pipe. A boot that turns the air 90° into a floor register costs **60 feet**. In a typical house, fittings are more than half of the total effective length.',
+            },
+            {
+                note: {
+                    kind: 'secret',
+                    title: 'Corollary worth tattooing on your forearm',
+                    body: 'The cheapest performance upgrade is always **deleting a fitting**. Moving the air handler ten feet to eliminate two elbows beats going up a duct size, costs nothing in material, and makes the system quieter.',
+                },
+            },
+            { h: 'Two rules you will use constantly' },
+            {
+                list: [
+                    '**Round beats rectangular.** Same cross-sectional area, less surface for the air to rub on, cheaper, faster to install, easier to seal. Use rectangular only where you need to fit a cavity.',
+                    '**Doubling the diameter carries about 5.7× the air** at the same friction. Duct capacity scales viciously fast, which is why going up one nominal size fixes so many problems.',
+                ],
+            },
+        ],
+    },
+
+    /* ------------------------------------------------ */
+    {
+        id: 'airflow',
+        step: 1,
+        nav: 'Step 1 · Airflow',
+        title: 'How much air, and who gets it',
+        subtitle: 'Total CFM for the equipment, then a fair split between rooms.',
+        calculator: 'AirflowPlanner',
+        blocks: [
+            { h: 'Total airflow' },
+            {
+                p: 'Start from the equipment, not the ducts. Cooling systems are designed around roughly **400 CFM per ton** of capacity. A 3-ton system moves about 1,200 CFM. Adjust for climate:',
+            },
+            {
+                table: {
+                    head: ['CFM per ton', 'When to use it', 'Why'],
+                    rows: [
+                        ['350', 'Humid climates, high latent load', 'Slower air spends longer on the coil and pulls out more moisture'],
+                        ['400', 'The default', 'What manufacturers rate equipment at'],
+                        ['450', 'Dry climates, heating-dominated', 'Sensible cooling only, or you need furnace airflow'],
+                    ],
+                },
+            },
+            {
+                note: {
+                    kind: 'warn',
+                    title: 'Do not size equipment from a rule of thumb',
+                    body: 'CFM per ton tells you the airflow **for the tonnage you already have**. It does not tell you what tonnage the house needs. That is a Manual J load calculation, and "500 square feet per ton" has oversized more houses than any other sentence in this trade. An oversized system short-cycles, never dehumidifies, and cannot be fixed with ductwork.',
+                },
+            },
+            { h: 'Splitting it between rooms' },
+            {
+                p: 'Air follows **load**, not floor area. A south-facing room with three windows needs far more air than a same-sized interior hallway. The right tool is a room-by-room Manual J. The calculator below is the honest beginner stand-in: floor area weighted by how exposed the room is.',
+            },
+            {
+                list: [
+                    'Interior room, no exterior walls — factor **1.0**',
+                    'One exterior wall, normal windows — factor **1.15**',
+                    'Corner room, or a wall of glass — factor **1.35**',
+                    'Room over a garage, attic room, sunroom — factor **1.6**',
+                ],
+            },
+            {
+                note: {
+                    kind: 'secret',
+                    title: 'The room that is always wrong',
+                    body: 'The bonus room over the garage. It has conditioned air on one side and outdoor temperatures on the other five, it sits at the end of the longest duct run, and it was sized by floor area. If you have one, give it its own generous branch straight off the plenum — or its own mini-split and stop fighting it.',
+                },
+            },
+            { h: 'Sanity checks on the split' },
+            {
+                list: [
+                    'No single branch should carry more than about **400 CFM**. Beyond that, run two branches — it is quieter and easier to balance.',
+                    'A bedroom typically lands at **75 to 150 CFM**. A living room at **200 to 400**.',
+                    'Bathrooms and closets usually get nothing. Exhaust fans handle bathrooms.',
+                    'If your split says a room needs 500 CFM, re-read the exposure factors before you believe it.',
+                ],
+            },
+        ],
+    },
+
+    /* ------------------------------------------------ */
+    {
+        id: 'pressure',
+        step: 2,
+        nav: 'Step 2 · Pressure budget',
+        title: 'What the blower has left to spend',
+        subtitle: 'Start with the blower rating, subtract every obstacle, keep the change.',
+        calculator: 'PressureBudget',
+        blocks: [
+            {
+                p: 'Open your equipment manual to the blower performance table. Find the row for the airflow you need at the speed tap you plan to use. The column heading tells you the maximum **external static pressure** the blower can work against and still deliver that CFM. That is the entire budget.',
+            },
+            {
+                note: {
+                    kind: 'secret',
+                    title: 'The double-counting trap',
+                    body: 'Read the fine print above the blower table. Many manufacturers publish airflow **with the cased coil and a clean filter already installed**. If you then subtract the coil and filter again, you will end up with almost no available pressure and duct sizes the size of a car. Check whether the table says "wet coil" or "with filter" before you subtract anything.',
+                },
+            },
+            { h: 'Everything that takes a bite' },
+            {
+                table: {
+                    head: ['Component', 'Typical drop (in.wc)', 'Notes'],
+                    rows: [
+                        ['Indoor coil, wet', '0.20 – 0.30', 'Wet is what matters — a dry coil reading flatters you'],
+                        ['1" pleated filter', '0.10 – 0.25', 'Rises steeply as it loads. Budget for dirty, not clean'],
+                        ['4" media filter', '0.05 – 0.10', 'More surface, less resistance, longer intervals'],
+                        ['Filter-back return grille', '0.10 – 0.20', 'Convenient, expensive in pressure'],
+                        ['Supply registers', '0.03 – 0.05', 'From the grille catalog, at actual CFM'],
+                        ['Return grilles', '0.03 – 0.05', 'Per grille, at actual CFM'],
+                        ['Balancing dampers', '0.03', 'Budget for them even if left open'],
+                        ['Humidifier / UV / zone dampers', '0.05 – 0.20', 'Anything in the airstream counts'],
+                    ],
+                },
+            },
+            {
+                note: {
+                    kind: 'tip',
+                    title: 'Bigger filters are free performance',
+                    body: 'Pressure drop across a filter depends on **face velocity**. Double the filter area and you roughly halve the drop, and it lasts twice as long between changes. Aim for at least 2 square feet of filter per 400 CFM — 4 square feet if you can fit it. This is the highest-return decision in the whole design and it costs almost nothing at rough-in.',
+                },
+            },
+            { h: 'What good looks like' },
+            {
+                list: [
+                    'A modern ECM air handler rated **0.7 in.wc**, minus a wet coil, decent filter, and grilles, leaves roughly **0.20 to 0.30 in.wc** for the ducts.',
+                    'An older PSC furnace rated **0.5 in.wc** may leave only **0.10 to 0.15**. Long runs on that budget need genuinely large ducts. That is not a mistake in your math — it is the truth about that blower.',
+                    'If your available pressure lands near zero, the fix is upstream: a bigger filter, a better coil, a stronger blower, or shorter duct runs. Do not "just make the ducts smaller."',
+                ],
+            },
+        ],
+    },
+
+    /* ------------------------------------------------ */
+    {
+        id: 'length',
+        step: 3,
+        nav: 'Step 3 · Effective length',
+        title: 'The longest path, in equivalent feet',
+        subtitle: 'Count the fittings. This is where the friction rate comes from.',
+        calculator: 'EffectiveLength',
+        blocks: [
+            {
+                p: 'Find the **worst run in the house**: from the blower, out through the supply plenum, along the trunk, down the branch, into the register of the farthest or most awkward room. Then the worst return path back to the blower. Measure both with a tape, then add an equivalent length for every fitting on the way.',
+            },
+            {
+                formula: {
+                    expression: 'TEL = supply feet + return feet + Σ (fitting equivalent lengths)',
+                    legend: [
+                        'One path only — not the total of every duct in the house',
+                        'Supply side and return side are added together, because the air travels both',
+                    ],
+                },
+            },
+            {
+                note: {
+                    kind: 'warn',
+                    title: 'The most common beginner error in this whole app',
+                    body: 'Do **not** add up all the ductwork in the building. TEL is one path: the single longest supply run plus the single longest return run. Summing everything gives you an enormous TEL, a microscopic friction rate, and duct sizes that will not fit in your joists.',
+                },
+            },
+            { h: 'Why fittings dominate' },
+            {
+                p: 'Look at what the fittings cost in the calculator below. A plain square 90° rectangular elbow is **45 equivalent feet**. Add turning vanes to that same elbow and it drops to **15**. A takeoff out the bottom of a trunk costs **65 feet**; the same takeoff angled off the side costs **35**.',
+            },
+            {
+                note: {
+                    kind: 'secret',
+                    title: 'Where the free wins are',
+                    body: 'Three substitutions cost almost nothing and routinely save 60+ equivalent feet: **turning vanes** in rectangular elbows, **angled or bellmouth takeoffs** instead of square ones, and taking off the **side** of a trunk instead of the bottom. That is more improvement than going up a duct size, for the price of better fittings.',
+                },
+            },
+            { h: 'Reading your result' },
+            {
+                table: {
+                    head: ['Friction rate', 'Verdict', 'What to do'],
+                    rows: [
+                        ['Below 0.06', 'Trouble', 'Ducts will be enormous. Shorten the run, delete fittings, or find more blower'],
+                        ['0.06 – 0.08', 'Low but workable', 'Expect generous sizes. That is the honest price of a long run'],
+                        ['0.08 – 0.18', 'Healthy', 'Normal residential territory. Size away'],
+                        ['Above 0.18', 'Suspicious', 'Usually means you understated TEL. Recount your fittings'],
+                    ],
+                },
+            },
+            {
+                note: {
+                    kind: 'tip',
+                    title: 'Why 0.10 is not the default',
+                    body: 'Old guides say "just use 0.10 in.wc per 100 ft." That was a reasonable guess for a compact 1960s system with a low-resistance filter. Modern houses have longer runs and modern filters and coils eat more pressure, so real systems commonly land between **0.06 and 0.10**. Using 0.10 blindly makes every duct in the house one size too small.',
+                },
+            },
+        ],
+    },
+
+    /* ------------------------------------------------ */
+    {
+        id: 'sizing',
+        step: 4,
+        nav: 'Step 4 · Size the ducts',
+        title: 'CFM plus friction rate equals a duct size',
+        subtitle: 'The payoff. Then a velocity check so you can sleep at night.',
+        calculator: 'DuctSizer',
+        blocks: [
+            {
+                p: 'You now have everything. For each run, feed in its CFM and the one friction rate you calculated for the whole house, and read off a size. Do this for the trunk, then every branch. It is genuinely this mechanical.',
+            },
+            {
+                formula: {
+                    expression: 'Pressure loss per 100 ft = 0.109136 × CFM^1.9 ÷ D^5.02',
+                    legend: [
+                        'D is inside diameter in inches, for smooth round metal pipe',
+                        'This is the equation printed on the back of every ductulator — solved for D, it gives you the size',
+                    ],
+                },
+            },
+            { h: 'Two checks, always' },
+            {
+                steps: [
+                    '**Friction check** — is the duct big enough to move the air within the pressure budget? That is what the equation above answers.',
+                    '**Velocity check** — is the air moving slowly enough to be quiet? Friction sizing alone will happily hand you a duct that works perfectly and sounds like a wind tunnel.',
+                ],
+            },
+            {
+                table: {
+                    head: ['Location', 'Target velocity (fpm)', 'Symptom if exceeded'],
+                    rows: [
+                        ['Supply trunk', '650 – 900', 'Audible rush through the house'],
+                        ['Supply branch', '450 – 700', 'Whistling and register noise in the room'],
+                        ['Return trunk', '550 – 800', 'Roar near the air handler'],
+                        ['Return branch', '350 – 600', 'The return grille becomes the loudest thing in the hall'],
+                    ],
+                },
+            },
+            {
+                note: {
+                    kind: 'secret',
+                    title: 'Always round up. Never round down.',
+                    body: 'If the math says 9.8 inches, install 10 — never 9. Rounding down raises velocity and friction on a curve, not a line, and the pressure you lose is gone forever. Rounding up costs a few dollars of metal and buys you quiet, plus headroom for the dirty filter you will inevitably run too long.',
+                },
+            },
+            { h: 'Rectangular when you must' },
+            {
+                p: 'Cavities force rectangular duct. Convert using **equivalent diameter** — the round pipe that loses the same pressure per foot. Keep the aspect ratio under **4:1**, ideally under **2:1**. A 20×5 duct and a 10×10 duct have nearly the same area, but the flat one uses more metal, loses more pressure, and costs more to fabricate.',
+            },
+            {
+                note: {
+                    kind: 'tip',
+                    title: 'Flex duct is not free',
+                    body: 'Fully stretched, flex duct has roughly **1.5×** the friction of metal at the same size. Let it sag and go slack and it can double again. As a working rule: if you must use flex, **go up one nominal size**, pull it drum tight, and support it every 4 to 5 feet. The calculator lets you pick the material so you can see the penalty.',
+                },
+            },
+        ],
+    },
+
+    /* ------------------------------------------------ */
+    {
+        id: 'returns',
+        step: 5,
+        nav: 'Step 5 · Returns',
+        title: 'The half everyone forgets',
+        subtitle: 'Undersized returns are the number one defect in DIY duct systems.',
+        calculator: 'ReturnSizer',
+        blocks: [
+            {
+                p: 'Every cubic foot the blower pushes out has to come back. If your supply system can deliver 1,200 CFM and your return path can only feed 800, you do not get 1,200 — you get a starving blower, high static pressure, a frozen or overheating coil, and a house that never quite gets comfortable.',
+            },
+            {
+                note: {
+                    kind: 'secret',
+                    title: 'The single highest-value rule in this app',
+                    body: 'Size the return path for the **entire blower airflow**, at a **lower velocity** than the supply. Then go one size bigger. Return duct is the cheapest insurance in HVAC — nobody has ever regretted an oversized return, and half of all "my system is too loud" complaints are an undersized one.',
+                },
+            },
+            { h: 'Grille sizing by face velocity' },
+            {
+                p: 'A grille is mostly blades. **Free area** is the actual hole — around 70% of the face on a stamped grille, 85% on a bar grille. Size by the velocity through that free area:',
+            },
+            {
+                list: [
+                    'Return grilles: **300 – 500 fpm** net. Above 500 you will hear it; above 600 you will hate it.',
+                    'Supply registers: **400 – 700 fpm** net, and check the manufacturer’s throw so the air actually reaches the far side of the room.',
+                    'Rule of thumb worth memorizing: **1 square foot of net free area per 400 CFM**. A 1,200 CFM system needs about 3 square feet of return free area — call it 4 square feet of grille face.',
+                ],
+            },
+            {
+                note: {
+                    kind: 'tip',
+                    title: 'Two returns beat one',
+                    body: 'A single 1,200 CFM return grille is enormous, loud, and gathers dust in one hallway. Two grilles at 600 CFM each are quieter, cheaper to fabricate, and pull air more evenly from the house. Put them in central spaces — hallways and living areas, high or low depending on your climate.',
+                },
+            },
+            { h: 'Closed doors are a hidden return problem' },
+            {
+                p: 'A bedroom with a supply register, a closed door, and no return becomes a pressurized balloon. Air stops flowing in, the room drifts out of temperature, and the pressure difference pulls unconditioned air through every gap in the wall. The fixes, best first:',
+            },
+            {
+                steps: [
+                    'A **dedicated return** in the room. Best performance, most work.',
+                    'A **jump duct** — a short flex loop over the wall from the room ceiling to the hallway ceiling. Quiet and preserves privacy.',
+                    'A **transfer grille** — a pair of offset wall grilles in the same stud bay. Cheap, but sound passes through.',
+                    'Undercutting the door. Better than nothing, and rarely enough on its own — a 1" undercut on a 30" door passes maybe 50 CFM.',
+                ],
+            },
+            {
+                note: {
+                    kind: 'warn',
+                    title: 'Never use building cavities as ducts',
+                    body: 'Panned joist bays, stud cavities, and "the space between the floors" are not ductwork. They leak enormously, they are impossible to seal or clean, they pull air out of the attic and crawlspace, and in most current codes they are simply not allowed. Run actual duct.',
+                },
+            },
+        ],
+    },
+
+    /* ------------------------------------------------ */
+    {
+        id: 'layout',
+        step: 6,
+        nav: 'Step 6 · Layout',
+        title: 'Draw it before you cut anything',
+        subtitle: 'Layout decisions cost pennies on paper and hundreds in sheet metal.',
+        blocks: [
+            { h: 'Pick a shape' },
+            {
+                table: {
+                    head: ['Layout', 'How it works', 'Best for'],
+                    rows: [
+                        ['Trunk and branch', 'One main duct with takeoffs along it, reducing as air peels off', 'Basements and crawlspaces. The workhorse — use this unless you have a reason not to'],
+                        ['Radial', 'Individual runs from a central plenum to each room', 'Slab-on-grade, compact single-story, attic installs'],
+                        ['Extended plenum', 'Constant-size trunk with branches, no reduction', 'Short runs under about 24 ft, where reducing is not worth the fittings'],
+                    ],
+                },
+            },
+            { h: 'Where the equipment goes' },
+            {
+                p: 'Central is the single biggest lever you have. Every foot the air handler moves toward the middle of the floor plan shortens the worst run, raises your friction rate, and shrinks every duct in the house.',
+            },
+            {
+                note: {
+                    kind: 'secret',
+                    title: 'The efficiency win that beats all the sizing math',
+                    body: 'Keep the ductwork **inside conditioned space**. Ducts in a vented attic can lose 20–30% of their capacity to leakage and heat transfer even when perfectly sized. A slightly undersized duct in a conditioned basement outperforms a perfectly sized one in a 130°F attic. If ducts must go in the attic, bury them in insulation or build a conditioned chase.',
+                },
+            },
+            { h: 'Reducing the trunk' },
+            {
+                p: 'As branches peel off, the trunk carries less air. Resize it so velocity stays in range instead of dropping to nothing:',
+            },
+            {
+                list: [
+                    'Reduce in **2 inch** increments — for rectangular trunk, reduce the **width** and keep the depth constant so it stays in the same cavity.',
+                    'Do not reduce for every branch. Reduce roughly every time you shed **a third of the airflow**, or when velocity falls below its target.',
+                    'Stop reducing at about **8 inches**. Below that the fittings cost more than the metal you save.',
+                    'A reducing fitting is only about **10 equivalent feet** — reducing is cheap. Use a gradual transition, not an abrupt step.',
+                ],
+            },
+            { h: 'Takeoffs and branches' },
+            {
+                list: [
+                    'Take off the **side** of the trunk, not the bottom. Side takeoffs cost 35 equivalent feet; bottom takeoffs cost 65.',
+                    'Keep takeoffs at least **6 to 12 inches** away from elbows, transitions, and the end cap — air coming out of a turn is turbulent and will not divide evenly.',
+                    'Never put a takeoff in the **first 18 inches** off the plenum. That air is still swirling off the blower.',
+                    'Put a **balancing damper at every takeoff**, at the trunk, where you can reach it. Not at the register — dampers at the register are the ones that whistle.',
+                    'Feed the farthest room from the **end** of the trunk, and give it a slightly generous branch. Distance always wins arguments.',
+                ],
+            },
+            { h: 'Registers in the room' },
+            {
+                list: [
+                    'Cold climates: registers **low, under windows**, throwing up across the glass to wash the cold surface.',
+                    'Hot climates: registers **high**, throwing across the ceiling so cool air falls through the room.',
+                    'Aim the throw across the room, not into a wall three feet away, and not straight at where people sit.',
+                    'Keep supply and return **apart**. Air that leaves a supply and returns immediately has done nothing for the room.',
+                ],
+            },
+            {
+                note: {
+                    kind: 'tip',
+                    title: 'Draw the whole thing to scale first',
+                    body: 'Sketch the plan, mark CFM at every register, then walk the trunk from the plenum outward writing the running total beside each section. Ten minutes with a pencil catches the joist you cannot cross and the beam you cannot get past — and that is the mistake that costs a weekend.',
+                },
+            },
+        ],
+    },
+
+    /* ------------------------------------------------ */
+    {
+        id: 'install',
+        step: 7,
+        nav: 'Step 7 · Build it',
+        title: 'Craft is what separates working from good',
+        subtitle: 'Sealing, supporting, and insulating — where the design gets thrown away or kept.',
+        blocks: [
+            { h: 'Sealing' },
+            {
+                note: {
+                    kind: 'secret',
+                    title: 'Duct tape does not seal ducts',
+                    body: 'Cloth duct tape dries out, curls off, and fails within a few years — it famously fails the test named after it. Use **water-based mastic** brushed on to about the thickness of a nickel, reinforced with mesh tape on any gap over 1/8". **UL 181 foil tape** is legitimate on clean, dry metal. Every longitudinal seam, every joint, every takeoff, and the equipment cabinet itself.',
+                },
+            },
+            {
+                list: [
+                    'Mechanically fasten before you seal: **three screws minimum** per round joint, then mastic over the whole seam.',
+                    'Seal the **plenum and the first five feet** obsessively. Leaks there are at the highest pressure in the system and leak the most air.',
+                    'Seal **before** you insulate. Nobody has ever gone back and done it after.',
+                    'Boots get sealed to the **subfloor or drywall**, not just to the duct. That connection leaks straight into the floor cavity.',
+                ],
+            },
+            { h: 'Supporting' },
+            {
+                list: [
+                    'Rigid metal: support every **8 to 10 feet**, and within 2 feet of every fitting.',
+                    'Flex duct: support every **4 to 5 feet** with straps at least **1.5 inches wide**. Wire and zip ties cut into the liner and choke the duct.',
+                    'Maximum sag: **1/2 inch per foot** of strap spacing. Flex duct sagging between supports is a series of hidden elbows.',
+                    'Never let duct rest on a joist edge, a pipe, or a wire. It crushes and it rattles.',
+                ],
+            },
+            { h: 'Flex duct, done properly' },
+            {
+                p: 'Flex is fast, quiet, and forgiving of imperfect geometry. It is also the most abused material in residential HVAC.',
+            },
+            {
+                steps: [
+                    'Pull it **drum tight** and cut to length. Compressed flex loses capacity fast — a few percent of compression can cost a third of the airflow.',
+                    'Cut the excess off. Do not coil the leftover in the attic "in case."',
+                    'Bend radius at least **one duct diameter**. Tighter than that and a single 90° bend costs 50 equivalent feet.',
+                    'Attach the inner liner to the collar with a **draw band on the liner**, seal with mastic, then bring the insulation and outer jacket over and band that separately.',
+                    'Never run flex over a sharp edge or through a hole barely big enough for it.',
+                ],
+            },
+            { h: 'Insulating' },
+            {
+                list: [
+                    'Unconditioned attic or crawlspace: **R-8 minimum** (many codes now require R-8; check yours).',
+                    'Conditioned basement: insulation is optional for energy, but useful for **condensation control** on cooling ducts and for noise.',
+                    'Any duct carrying cold air through humid unconditioned space needs a **continuous vapor barrier**, taped at every seam, or it will rain on your ceiling.',
+                ],
+            },
+            { h: 'Tools that earn their keep' },
+            {
+                list: [
+                    '**Manometer**, dual port — non-negotiable for verification.',
+                    '**Snips** (left, right, and straight), hand seamer, and crimpers.',
+                    '**Hole saw or duct knife** for takeoff collars.',
+                    '**Mastic and mesh tape**, plus a cheap brush you will throw away.',
+                    '**Self-tapping screws**, 3/8" hex head. A magnetic impact driver bit.',
+                    '**Anemometer** or flow hood for balancing. A vane anemometer plus a known free area is enough to get close.',
+                ],
+            },
+            {
+                note: {
+                    kind: 'warn',
+                    title: 'Wear gloves and eye protection',
+                    body: 'Cut sheet metal edges are genuinely dangerous, and fiberglass insulation in an attic is worse. Long sleeves, gloves, safety glasses, and a respirator when handling insulation or working in an old attic. Kneel on plywood, not on the drywall between joists.',
+                },
+            },
+        ],
+    },
+
+    /* ------------------------------------------------ */
+    {
+        id: 'verify',
+        step: 8,
+        nav: 'Step 8 · Verify',
+        title: 'Measure it, or you only think it works',
+        subtitle: 'Four readings that confirm the design and one that finds the leaks.',
+        blocks: [
+            {
+                p: 'A design is a hypothesis. These measurements test it, and they take under an hour once the system is running.',
+            },
+            { h: '1. Total external static pressure' },
+            {
+                steps: [
+                    'Drill two 3/8" test ports: one in the **return** just before the air handler (upstream of the filter and coil), one in the **supply** plenum just after.',
+                    'Run the blower on the speed you designed for, with a clean filter and all registers open.',
+                    'Read both ports with the manometer and add the magnitudes. That is your total external static pressure.',
+                    'Compare it to the blower table. Higher than rated means the system is more restrictive than you planned.',
+                    'Plug the ports with the supplied caps when you are done.',
+                ],
+            },
+            {
+                note: {
+                    kind: 'secret',
+                    title: 'The diagnostic pros run first, every time',
+                    body: 'Measure the drop across each component individually — filter, coil, supply side, return side. The one with a drop far above its spec is your problem, and now you know exactly what to fix instead of guessing. Most "weak airflow" calls are one restrictive filter or one crushed flex run.',
+                },
+            },
+            { h: '2. Airflow at the registers' },
+            {
+                p: 'A flow hood is ideal. A vane anemometer plus the register’s published free area gets you within about 10%, which is plenty for balancing. Compare each room to your Step 1 target and adjust the **trunk takeoff dampers** — starve the close rooms so the far ones get their share. Work from the closest room outward, and re-check the far rooms after every adjustment.',
+            },
+            { h: '3. Temperature split' },
+            {
+                p: 'Measure dry-bulb temperature in the return and the supply. Cooling should show roughly a **16 to 22°F** drop. A split much larger than that usually means airflow is too low; much smaller usually means low refrigerant charge or too much airflow. It is a crude check that catches gross errors fast.',
+            },
+            { h: '4. Room-to-room temperature' },
+            {
+                p: 'On a design day, no room should be more than about **2°F** from the thermostat. More than that and either the airflow split is wrong or that room’s load is bigger than you estimated.',
+            },
+            { h: '5. Find the leaks' },
+            {
+                list: [
+                    'Run the blower and feel every joint with the back of your hand. You will find more than you expect.',
+                    'A stick of incense makes leaks visible in dim light.',
+                    'A **duct blaster** test gives you a real leakage number — many jurisdictions require one on new work anyway.',
+                    'Sealed properly, total duct leakage should be a few percent of system airflow. Typical unsealed residential ductwork leaks **20 to 30%**.',
+                ],
+            },
+            {
+                note: {
+                    kind: 'tip',
+                    title: 'Write it down and leave it in the cabinet',
+                    body: 'Tape a card inside the air handler door: design CFM, design friction rate, measured static pressure, measured CFM per room, damper positions, and the date. In five years that card is worth more than your memory, and the next person to touch the system will thank you.',
+                },
+            },
+        ],
+    },
+];
+
+export function findLesson(id) {
+    return LESSONS.find((lesson) => lesson.id === id);
+}

--- a/src/_hvac/data/quiz.js
+++ b/src/_hvac/data/quiz.js
@@ -1,0 +1,109 @@
+/*
+Self-check questions. Each one targets a specific mistake
+that shows up in real DIY installs, and the explanation is
+the actual lesson — getting it wrong should teach you more
+than getting it right.
+*/
+
+export const QUIZ = [
+    {
+        question: 'Total effective length is the sum of…',
+        options: [
+            'Every duct in the house, plus fittings',
+            'The longest supply run plus the longest return run, plus the fittings on that path',
+            'The trunk length only',
+            'The distance from the air handler to the thermostat',
+        ],
+        answer: 1,
+        explanation:
+            'One path only. Summing all the ductwork in the building gives you a huge TEL, a tiny friction rate, and duct sizes that will not fit in your joists. The air travels out and back, so supply and return are added together.',
+    },
+    {
+        question: 'Your math says a branch needs 9.8" of round duct. You install…',
+        options: ['9" — closest size', '10" — round up', '8" — it will be fine', '12" — round up two sizes to be safe'],
+        answer: 1,
+        explanation:
+            'Always round up to the next available size, never down. Friction and velocity rise on a curve, so the inch you shave off costs more than it looks like it should. Rounding up two sizes is not wrong, just unnecessary spending — and very low velocity has its own problems.',
+    },
+    {
+        question: 'A 90° rectangular elbow with no turning vanes costs about how much equivalent length?',
+        options: ['1 foot — it is only a foot long', '5 feet', '45 feet', '200 feet'],
+        answer: 2,
+        explanation:
+            'About 45 equivalent feet. Add turning vanes and the same elbow drops to roughly 15. Fittings, not straight duct, are usually the majority of total effective length — which is why deleting a fitting beats upsizing a duct.',
+    },
+    {
+        question: 'You have a 1,200 CFM system. How much air does the return path need to carry?',
+        options: [
+            'About 400 CFM — returns are shared',
+            'Whatever the biggest room needs',
+            'The full 1,200 CFM, at a lower velocity than the supply',
+            'Half the supply, since return duct is bigger',
+        ],
+        answer: 2,
+        explanation:
+            'Every cubic foot pushed out has to come back. Size the return for the entire blower airflow at a lower velocity — 300 to 500 fpm through the grille free area — and then go up a size. Undersized returns are the number one defect in DIY duct systems.',
+    },
+    {
+        question: 'Your blower table shows 1,200 CFM at 0.7 in.wc. After subtracting coil, filter, and grilles you have 0.22 in.wc left, and your TEL is 275 ft. What is the friction rate?',
+        options: ['0.0008', '0.08', '0.22', '2.75'],
+        answer: 1,
+        explanation:
+            '(0.22 × 100) ÷ 275 = 0.08 in.wc per 100 ft. That is a healthy residential number. Notice it is well below the old 0.10 default — which is exactly why using 0.10 blindly undersizes real systems.',
+    },
+    {
+        question: 'A bedroom has one supply register, no return, and the door stays closed at night. What happens?',
+        options: [
+            'Nothing — the door undercut handles it',
+            'The room pressurizes, airflow into it drops, and the pressure pushes air through gaps in the walls',
+            'The register gets louder but airflow is unaffected',
+            'The return grille in the hallway pulls air through the wall',
+        ],
+        answer: 1,
+        explanation:
+            'It becomes a balloon. Air cannot get out, so less gets in, the room drifts out of temperature, and the pressure difference drives unconditioned air through every gap. Fix it with a dedicated return, a jump duct, or a transfer grille. A 1" undercut on a 30" door passes only about 50 CFM.',
+    },
+    {
+        question: 'You need to use flex duct for a branch. Compared to rigid metal of the same size, fully stretched flex has…',
+        options: ['Identical friction', 'About 1.5× the friction', 'Less friction — it is smoother', 'About 10× the friction'],
+        answer: 1,
+        explanation:
+            'Roughly 1.5× when pulled drum tight, and it gets much worse as it goes slack or compresses. Working rule: go up one nominal size, pull it tight, cut off the excess, and support it every 4 to 5 feet with 1.5" straps.',
+    },
+    {
+        question: 'Which change most improves a duct system, dollar for dollar?',
+        options: [
+            'Upgrading every branch one size',
+            'Getting the ductwork inside conditioned space',
+            'Adding a second filter',
+            'Using rectangular duct instead of round',
+        ],
+        answer: 1,
+        explanation:
+            'Ducts in a vented attic can lose 20 to 30% of their capacity to leakage and heat transfer no matter how well they are sized. A slightly undersized duct in a conditioned basement beats a perfectly sized one in a 130°F attic. Round beats rectangular, by the way — the last option is backwards.',
+    },
+    {
+        question: 'Where do balancing dampers belong?',
+        options: [
+            'At the register, so you can adjust them from the room',
+            'At the trunk takeoff, accessible from the basement or attic',
+            'Inside the plenum',
+            'Nowhere — balance by closing registers',
+        ],
+        answer: 1,
+        explanation:
+            'At the takeoff, where the trunk splits. Dampers at the register whistle and put the noise in the room. Closing registers to balance raises system static pressure and makes everything worse.',
+    },
+    {
+        question: 'The first thing to measure on a finished system is…',
+        options: [
+            'Refrigerant pressure',
+            'Total external static pressure, with a manometer at ports before and after the air handler',
+            'Room temperature',
+            'The electric bill next month',
+        ],
+        answer: 1,
+        explanation:
+            'Static pressure is the blood pressure of the system. Two 3/8" test ports, one reading, five minutes, and you know whether the duct system you built matches the one you designed. Then measure the drop across each component to find which one is the problem.',
+    },
+];

--- a/src/_hvac/data/secrets.js
+++ b/src/_hvac/data/secrets.js
@@ -1,0 +1,150 @@
+/*
+The cheat sheet. Everything an experienced installer knows
+that no beginner guide bothers to say out loud, grouped so
+it is scannable on a phone in a crawlspace.
+*/
+
+export const SECRET_GROUPS = [
+    {
+        title: 'Sizing',
+        secrets: [
+            {
+                rule: 'Calculate the friction rate once, then reuse it everywhere.',
+                why: 'One number from the worst run in the house sizes every duct in the building. Beginners think each run gets its own calculation. It does not.',
+            },
+            {
+                rule: 'Always round up to the next available size.',
+                why: 'Friction and velocity rise on a curve, not a line. Rounding 9.8" down to 9" costs far more than the inch suggests, and the pressure is gone permanently.',
+            },
+            {
+                rule: 'Do not blindly use 0.10 in.wc per 100 ft.',
+                why: 'It was a fair guess for compact 1960s systems. Modern filters, coils, and longer runs put real houses between 0.06 and 0.10. Using 0.10 makes every duct one size too small.',
+            },
+            {
+                rule: 'Total effective length is one path, not all the duct.',
+                why: 'Longest supply run plus longest return run. Summing the whole house produces a tiny friction rate and comically oversized ducts.',
+            },
+            {
+                rule: 'Never run a single branch over about 400 CFM.',
+                why: 'Two smaller branches are quieter, easier to balance, and easier to route than one big one.',
+            },
+        ],
+    },
+    {
+        title: 'Returns',
+        secrets: [
+            {
+                rule: 'Size the return for the whole blower, at lower velocity, then go up one size.',
+                why: 'Return duct is the cheapest insurance in HVAC. Undersized returns cause high static pressure, low airflow, frozen coils, and most noise complaints.',
+            },
+            {
+                rule: 'One square foot of net free grille area per 400 CFM.',
+                why: 'The fastest sanity check there is. A 1,200 CFM system needs roughly 3 sq ft of free area — about 4 sq ft of grille face on a stamped grille.',
+            },
+            {
+                rule: 'Every bedroom with a closed door needs a way for air to get out.',
+                why: 'Otherwise it pressurizes, airflow stalls, and the pressure difference drags unconditioned air through the walls. Jump duct or transfer grille — a door undercut alone rarely does it.',
+            },
+            {
+                rule: 'Never use stud bays or panned joists as ducts.',
+                why: 'They leak enormously, cannot be sealed or cleaned, pull air from attics and crawlspaces, and are prohibited by most current codes.',
+            },
+        ],
+    },
+    {
+        title: 'Fittings and layout',
+        secrets: [
+            {
+                rule: 'Deleting a fitting beats upsizing a duct.',
+                why: 'One rectangular elbow without vanes is 45 equivalent feet. Moving the air handler to delete two elbows is free performance and less noise.',
+            },
+            {
+                rule: 'Turning vanes, angled takeoffs, side takeoffs.',
+                why: 'Three cheap substitutions that routinely save 60+ equivalent feet: vanes drop an elbow from 45 ft to 15, angled takeoffs beat square by 15 ft, side beats bottom by 30.',
+            },
+            {
+                rule: 'Round beats rectangular whenever it fits.',
+                why: 'Less surface per unit area, less friction, cheaper, faster, easier to seal. Use rectangular only to fit a cavity, and keep aspect ratio under 4:1.',
+            },
+            {
+                rule: 'Keep takeoffs 6–12" clear of elbows, transitions, and end caps.',
+                why: 'Air coming out of a turn is turbulent and will not divide evenly. Never take off within 18" of the plenum.',
+            },
+            {
+                rule: 'Reduce the trunk in 2" steps, and stop at 8".',
+                why: 'Reduce width and keep depth so it stays in the same cavity. Below 8" the fittings cost more than the metal you save.',
+            },
+            {
+                rule: 'Balancing dampers at the trunk takeoff, never at the register.',
+                why: 'Dampers at the register whistle and put the noise in the room. Dampers at the trunk are quiet, and you can reach them without a ladder.',
+            },
+        ],
+    },
+    {
+        title: 'Equipment and pressure',
+        secrets: [
+            {
+                rule: 'Read the fine print above the blower table.',
+                why: 'Many manufacturers publish airflow with the cased coil and filter already installed. Subtract them again and you will design duct the size of a car.',
+            },
+            {
+                rule: 'A bigger filter is the cheapest upgrade in the system.',
+                why: 'Pressure drop tracks face velocity. Double the area and you roughly halve the drop and double the service interval. Aim for 2 sq ft per 400 CFM, 4 if it fits.',
+            },
+            {
+                rule: 'Budget for a dirty filter, not a clean one.',
+                why: 'A 1" pleated filter can go from 0.10 to 0.25 in.wc as it loads. Design at the dirty number or the system falls apart every three months.',
+            },
+            {
+                rule: 'Oversized equipment cannot be fixed with ductwork.',
+                why: 'It short-cycles, never dehumidifies, and wears out early. Get a real Manual J before you buy. "500 square feet per ton" has ruined more houses than bad ducts.',
+            },
+        ],
+    },
+    {
+        title: 'Installation craft',
+        secrets: [
+            {
+                rule: 'Mastic, not duct tape.',
+                why: 'Cloth duct tape fails on ducts — the test is famous. Brush mastic a nickel thick, mesh tape any gap over 1/8". UL 181 foil tape is acceptable on clean dry metal.',
+            },
+            {
+                rule: 'Seal the plenum and the first five feet obsessively.',
+                why: 'That is the highest-pressure duct in the system, so it leaks the most per square inch of hole. Seal the equipment cabinet too.',
+            },
+            {
+                rule: 'Flex duct must be pulled drum tight and cut to length.',
+                why: 'A few percent of compression can cost a third of the capacity. Support every 4–5 ft with 1.5" straps, max 1/2" sag per foot, bend radius at least one diameter.',
+            },
+            {
+                rule: 'Keep ducts inside conditioned space.',
+                why: 'The largest efficiency win available, bigger than any sizing decision. Attic ducts can lose 20–30% of capacity to leakage and heat gain even when perfectly sized.',
+            },
+            {
+                rule: 'Seal before you insulate.',
+                why: 'Nobody ever goes back and does it afterward.',
+            },
+        ],
+    },
+    {
+        title: 'Verification',
+        secrets: [
+            {
+                rule: 'Own a manometer. Measure static pressure on every job.',
+                why: 'It is the blood pressure of the system and the fastest diagnostic there is. Two test ports and five minutes tell you more than an hour of guessing.',
+            },
+            {
+                rule: 'Measure the drop across each component separately.',
+                why: 'Filter, coil, supply, return. The one reading far above spec is your problem. Most weak-airflow complaints are one restrictive filter or one crushed flex run.',
+            },
+            {
+                rule: 'Balance from the closest room outward, and re-check the far rooms.',
+                why: 'Closing a near damper pushes air everywhere else. Every adjustment changes every other room, so it takes two or three passes.',
+            },
+            {
+                rule: 'Tape a card with the design numbers inside the air handler door.',
+                why: 'Design CFM, friction rate, measured static, room airflows, damper positions, date. In five years it is worth more than your memory.',
+            },
+        ],
+    },
+];

--- a/src/_hvac/hooks/useHashRoute.js
+++ b/src/_hvac/hooks/useHashRoute.js
@@ -1,0 +1,26 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/*
+Routing, all of it. The app has one page and a dozen views,
+so the URL hash is enough — no router dependency, no server
+rewrites, and every view is still linkable and bookmarkable.
+*/
+
+const readHash = () => window.location.hash.replace(/^#\/?/, '') || null;
+
+export function useHashRoute(fallback) {
+    const [route, setRoute] = useState(() => readHash() ?? fallback);
+
+    useEffect(() => {
+        const sync = () => setRoute(readHash() ?? fallback);
+        window.addEventListener('hashchange', sync);
+        return () => window.removeEventListener('hashchange', sync);
+    }, [fallback]);
+
+    const navigate = useCallback((next) => {
+        window.location.hash = `#/${next}`;
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    }, []);
+
+    return [route, navigate];
+}

--- a/src/_hvac/hooks/usePersistentState.js
+++ b/src/_hvac/hooks/usePersistentState.js
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+/*
+useState that survives a reload. Someone planning ductwork
+will close the laptop halfway through, and losing the
+worksheet would make the app useless for real work.
+
+Storage failures are ignored on purpose — private browsing
+and full quotas should degrade to a normal, working app
+rather than a blank screen.
+*/
+export function usePersistentState(key, initialValue) {
+    const [value, setValue] = useState(() => {
+        try {
+            const stored = window.localStorage.getItem(key);
+            return stored ? { ...initialValue, ...JSON.parse(stored) } : initialValue;
+        } catch {
+            return initialValue;
+        }
+    });
+
+    useEffect(() => {
+        try {
+            window.localStorage.setItem(key, JSON.stringify(value));
+        } catch {
+            /* nothing useful to do here */
+        }
+    }, [key, value]);
+
+    const reset = () => setValue(initialValue);
+
+    return [value, setValue, reset];
+}

--- a/src/_hvac/index.jsx
+++ b/src/_hvac/index.jsx
@@ -1,0 +1,9 @@
+import { createRoot } from 'react-dom/client';
+
+import App from './App.jsx';
+
+const container = document.getElementById('hvac-root');
+
+if (container) {
+    createRoot(container).render(<App />);
+}

--- a/src/_hvac/lib/derive.js
+++ b/src/_hvac/lib/derive.js
@@ -1,0 +1,76 @@
+/*
+One place where the worksheet turns into results.
+
+Every calculator reads from here instead of doing its own
+math, which is why a change on the airflow screen instantly
+moves the duct sizes on the sizing screen. That chain is the
+whole point of the app: eight steps, one connected answer.
+*/
+
+import {
+    MATERIALS,
+    availableStaticPressure,
+    distributeCfm,
+    frictionRate,
+    gradeFrictionRate,
+    systemCfm,
+} from './ductMath.js';
+
+import { STARTER_SELECTIONS, totalEffectiveLength } from './fittings.js';
+
+let nextRoomId = 0;
+const room = (name, area, exposure) => ({ id: `room-${nextRoomId++}`, name, area, exposure });
+
+/* A believable 3-ton, single-trunk basement system to start from. */
+export const DEFAULT_SYSTEM = {
+    tons: 3,
+    cfmPerTon: 400,
+    rooms: [
+        room('Living room', 320, 1.35),
+        room('Kitchen / dining', 260, 1.15),
+        room('Primary bedroom', 200, 1.35),
+        room('Bedroom 2', 140, 1.15),
+        room('Bedroom 3', 130, 1.15),
+        room('Hallway / office', 150, 1.0),
+    ],
+    blowerEsp: 0.7,
+    drops: {
+        coil: 0.25,
+        filter: 0.15,
+        supplyRegisters: 0.03,
+        returnGrilles: 0.03,
+        balancingDampers: 0.03,
+        accessories: 0,
+    },
+    supplyRun: 45,
+    returnRun: 25,
+    fittings: { ...STARTER_SELECTIONS },
+    material: 'galvanized',
+};
+
+export function derive(system) {
+    const totalCfm = systemCfm(system.tons, system.cfmPerTon);
+    const rooms = distributeCfm(system.rooms, totalCfm);
+    const { spent, available } = availableStaticPressure(system.blowerEsp, system.drops);
+
+    const tel = totalEffectiveLength({
+        supplyRun: system.supplyRun,
+        returnRun: system.returnRun,
+        selections: system.fittings,
+    });
+
+    const rate = frictionRate(available, tel.total);
+
+    return {
+        totalCfm,
+        rooms,
+        spent,
+        available,
+        tel,
+        rate,
+        rateGrade: gradeFrictionRate(rate),
+        material: MATERIALS[system.material],
+        materialFactor: MATERIALS[system.material].factor,
+        largestRoomCfm: rooms.reduce((max, item) => Math.max(max, item.cfm), 0),
+    };
+}

--- a/src/_hvac/lib/ductMath.js
+++ b/src/_hvac/lib/ductMath.js
@@ -1,0 +1,343 @@
+/*
+===================================================
+DUCT MATH
+===================================================
+Every number the app shows comes from a function in
+this file. They are all pure so they can be tested
+without a browser (see ductMath.test.js).
+
+The core relationship is the ASHRAE friction-chart
+approximation for round galvanized duct:
+
+    dP100 = 0.109136 * CFM^1.9 / D^5.02
+
+    dP100 = pressure lost per 100 ft, inches of water column
+    CFM   = airflow, cubic feet per minute
+    D     = inside diameter, inches
+
+Solved for D it becomes the "ductulator" every HVAC
+tech carries in their pocket.
+*/
+
+const FRICTION_COEFFICIENT = 0.109136;
+const CFM_EXPONENT = 1.9;
+const DIAMETER_EXPONENT = 5.02;
+
+/*
+Roughness multipliers relative to smooth galvanized pipe.
+These are teaching approximations. ACCA Manual D has real
+tables per material — use those for permit drawings.
+*/
+export const MATERIALS = {
+    galvanized: { label: 'Rigid metal pipe', factor: 1.0, note: 'The baseline. Smoothest, cheapest per CFM delivered.' },
+    ductBoard: { label: 'Fiberglass duct board', factor: 1.3, note: 'Rougher inside than metal. Size up if runs are long.' },
+    flexTight: { label: 'Flex, pulled drum tight', factor: 1.5, note: 'Acceptable for short branch runs when fully stretched.' },
+    flexSloppy: { label: 'Flex, slightly slack', factor: 2.4, note: 'What most DIY installs actually look like. Avoid.' },
+};
+
+/* Sizes you can actually buy off the shelf at a supply house. */
+export const ROUND_SIZES = [4, 5, 6, 7, 8, 9, 10, 12, 14, 16, 18, 20, 22, 24];
+
+/* Sheet metal trunk depths that fit common joist and soffit cavities. */
+export const RECT_DEPTHS = [6, 8, 10, 12, 14];
+
+/*
+---------------------------------------------------
+AIRFLOW
+---------------------------------------------------
+*/
+
+/*
+Nominal airflow for a system. 400 CFM per ton is the
+textbook number; drop toward 350 in humid climates so the
+coil has time to wring out moisture, and push toward 450
+in dry climates or heat-dominated systems.
+*/
+export const CFM_PER_TON_PRESETS = [
+    { value: 350, label: '350 — humid climate, dehumidification matters' },
+    { value: 400, label: '400 — standard cooling default' },
+    { value: 450, label: '450 — dry climate or heating-dominated' },
+];
+
+export function systemCfm(tons, cfmPerTon = 400) {
+    return tons * cfmPerTon;
+}
+
+/*
+Room-by-room airflow. A real Manual J calculates the heat
+gain of every room and splits the air by load share. This
+is the beginner stand-in: floor area weighted by how hard
+the room is to condition. It gets you close enough to buy
+the right fittings, and it teaches the right instinct —
+air follows load, not square footage.
+*/
+export const EXPOSURE_FACTORS = [
+    { value: 1.0, label: 'Interior room, no exterior walls' },
+    { value: 1.15, label: 'One exterior wall, normal windows' },
+    { value: 1.35, label: 'Corner room, or a big window wall' },
+    { value: 1.6, label: 'Bonus room over garage, attic room, sunroom' },
+];
+
+export function distributeCfm(rooms, totalCfm) {
+    const weights = rooms.map((room) => Math.max(0, room.area) * room.exposure);
+    const totalWeight = weights.reduce((sum, weight) => sum + weight, 0);
+
+    return rooms.map((room, index) => ({
+        ...room,
+        share: totalWeight > 0 ? weights[index] / totalWeight : 0,
+        cfm: totalWeight > 0 ? Math.round((weights[index] / totalWeight) * totalCfm) : 0,
+    }));
+}
+
+/*
+---------------------------------------------------
+PRESSURE BUDGET
+---------------------------------------------------
+The blower can only push so hard. Everything bolted into
+the airstream takes a bite out of that. Whatever survives
+is what the duct runs get to spend.
+*/
+
+/* Typical drops in inches of water column. Always prefer the real spec sheet. */
+export const COMPONENT_DROPS = [
+    { id: 'coil', label: 'Indoor coil (wet)', typical: 0.25, hint: 'Check the blower table first — cased units often include it.' },
+    { id: 'filter', label: 'Air filter', typical: 0.15, hint: '1" pleated at design flow. A 4" media filter is closer to 0.08.' },
+    { id: 'supplyRegisters', label: 'Supply registers', typical: 0.03, hint: 'Per the grille catalog, at the airflow the register actually sees.' },
+    { id: 'returnGrilles', label: 'Return grilles', typical: 0.03, hint: 'Filter-back return grilles run much higher — 0.10 and up.' },
+    { id: 'balancingDampers', label: 'Balancing dampers', typical: 0.03, hint: 'Budget for them even if you plan to leave them wide open.' },
+    { id: 'accessories', label: 'Humidifier, UV, zone dampers', typical: 0.0, hint: 'Anything else in the airstream. Add it up.' },
+];
+
+export function availableStaticPressure(blowerEsp, drops) {
+    const spent = Object.values(drops).reduce((sum, drop) => sum + (Number(drop) || 0), 0);
+    return { spent, available: blowerEsp - spent };
+}
+
+/*
+Friction rate is the budget spread over the distance the
+air has to travel. This single number drives every duct
+size in the house.
+*/
+export function frictionRate(availablePressure, totalEffectiveLength) {
+    if (totalEffectiveLength <= 0) return 0;
+    return (availablePressure * 100) / totalEffectiveLength;
+}
+
+/*
+Sanity check on a friction rate. Manual D flags anything
+outside roughly 0.06–0.18 as a system that needs rethinking
+rather than resizing.
+*/
+export function gradeFrictionRate(rate) {
+    if (rate <= 0) return { level: 'bad', message: 'No pressure left. The equipment, filter, or coil is eating the whole budget.' };
+    if (rate < 0.06) return { level: 'bad', message: 'Very low. Ducts will be huge and expensive. Shorten runs, cut fittings, or find a blower with more capacity.' };
+    if (rate < 0.08) return { level: 'warn', message: 'Low but workable. Expect generous duct sizes — that is the honest cost of a long run.' };
+    if (rate <= 0.18) return { level: 'good', message: 'Healthy range. Standard sizing practice applies.' };
+    return { level: 'warn', message: 'High. Ducts will be small and possibly noisy. Double-check your effective length — short runs are the usual cause.' };
+}
+
+/*
+---------------------------------------------------
+ROUND DUCT SIZING
+---------------------------------------------------
+*/
+
+export function frictionPer100ft(cfm, diameter, materialFactor = 1) {
+    if (cfm <= 0 || diameter <= 0) return 0;
+    return (FRICTION_COEFFICIENT * Math.pow(cfm, CFM_EXPONENT) * materialFactor) / Math.pow(diameter, DIAMETER_EXPONENT);
+}
+
+/* The ductulator, solved for diameter. */
+export function requiredDiameter(cfm, rate, materialFactor = 1) {
+    if (cfm <= 0 || rate <= 0) return 0;
+    const numerator = FRICTION_COEFFICIENT * Math.pow(cfm, CFM_EXPONENT) * materialFactor;
+    return Math.pow(numerator / rate, 1 / DIAMETER_EXPONENT);
+}
+
+export function cfmAtSize(diameter, rate, materialFactor = 1) {
+    if (diameter <= 0 || rate <= 0) return 0;
+    const numerator = (rate * Math.pow(diameter, DIAMETER_EXPONENT)) / (FRICTION_COEFFICIENT * materialFactor);
+    return Math.pow(numerator, 1 / CFM_EXPONENT);
+}
+
+/* Never round down. Rounding down is how systems get loud. */
+export function nextRoundSize(diameter) {
+    return ROUND_SIZES.find((size) => size >= diameter) ?? ROUND_SIZES[ROUND_SIZES.length - 1];
+}
+
+/* 144 sq in per sq ft, circle area = pi * d^2 / 4  ->  cfm * 183.35 / d^2 */
+export function roundVelocity(cfm, diameter) {
+    if (diameter <= 0) return 0;
+    return (cfm * 4 * 144) / (Math.PI * diameter * diameter);
+}
+
+export function rectVelocity(cfm, width, height) {
+    if (width <= 0 || height <= 0) return 0;
+    return (cfm * 144) / (width * height);
+}
+
+/*
+---------------------------------------------------
+RECTANGULAR EQUIVALENTS
+---------------------------------------------------
+Two rectangular ducts with the same equivalent diameter
+lose the same pressure per foot:
+
+    De = 1.30 * (a*b)^0.625 / (a+b)^0.25
+*/
+
+export function equivalentDiameter(width, height) {
+    if (width <= 0 || height <= 0) return 0;
+    return (1.3 * Math.pow(width * height, 0.625)) / Math.pow(width + height, 0.25);
+}
+
+/*
+There is no clean algebraic inverse, so bisect. The
+function is monotonic in width, which makes this reliable
+and about ten lines shorter than the alternatives.
+*/
+export function widthForEquivalentDiameter(height, targetDe, tolerance = 0.01) {
+    let low = 1;
+    let high = 200;
+
+    while (high - low > tolerance) {
+        const mid = (low + high) / 2;
+        if (equivalentDiameter(mid, height) < targetDe) low = mid;
+        else high = mid;
+    }
+    return (low + high) / 2;
+}
+
+/* Round up to the next even inch — that is how sheet metal is fabricated. */
+function roundUpToEvenInch(value) {
+    return Math.ceil(value / 2) * 2;
+}
+
+export function rectangularOptions(targetDe, cfm, depths = RECT_DEPTHS) {
+    return depths
+        .map((depth) => {
+            const width = roundUpToEvenInch(widthForEquivalentDiameter(depth, targetDe));
+            return {
+                width,
+                depth,
+                aspectRatio: width / depth,
+                velocity: rectVelocity(cfm, width, depth),
+            };
+        })
+        .filter((option) => option.width >= option.depth);
+}
+
+/*
+Aspect ratio is a cost and performance tax. A 4:1 duct
+moves the same air as a 1:1 duct of equal area while
+using far more metal and losing more pressure.
+*/
+export function gradeAspectRatio(ratio) {
+    if (ratio <= 2) return { level: 'good', message: 'Efficient shape' };
+    if (ratio <= 4) return { level: 'warn', message: 'Acceptable, more metal and more friction' };
+    return { level: 'bad', message: 'Too flat — poor performer, avoid' };
+}
+
+/*
+---------------------------------------------------
+VELOCITY LIMITS
+---------------------------------------------------
+Friction sizing tells you what fits the pressure budget.
+Velocity tells you whether you will be able to sleep in
+the room. Residential targets, feet per minute.
+*/
+export const VELOCITY_LIMITS = {
+    supplyTrunk: { min: 650, max: 900, label: 'Supply trunk' },
+    supplyBranch: { min: 450, max: 700, label: 'Supply branch' },
+    returnTrunk: { min: 550, max: 800, label: 'Return trunk' },
+    returnBranch: { min: 350, max: 600, label: 'Return branch' },
+};
+
+export function gradeVelocity(velocity, limitKey) {
+    const limit = VELOCITY_LIMITS[limitKey];
+    if (velocity > limit.max) {
+        return { level: 'bad', message: `Above ${limit.max} fpm — expect audible rush. Go up a size.` };
+    }
+    if (velocity < limit.min) {
+        return { level: 'warn', message: `Below ${limit.min} fpm — quiet, but the air may not reach the far wall. Fine if you meant it.` };
+    }
+    return { level: 'good', message: `In the ${limit.min}–${limit.max} fpm sweet spot.` };
+}
+
+/*
+---------------------------------------------------
+GRILLES AND REGISTERS
+---------------------------------------------------
+A grille's face is mostly blades, not opening. Free area
+ratio converts face size to the hole the air actually
+squeezes through.
+*/
+export const GRILLE_TYPES = {
+    stamped: { label: 'Stamped face (the cheap ones)', freeArea: 0.7 },
+    bar: { label: 'Bar or louvered face', freeArea: 0.85 },
+};
+
+/* Net free area needed, in square inches. */
+export function requiredFreeArea(cfm, faceVelocity) {
+    if (faceVelocity <= 0) return 0;
+    return (cfm * 144) / faceVelocity;
+}
+
+export function requiredGrilleFaceArea(cfm, faceVelocity, freeAreaRatio) {
+    if (freeAreaRatio <= 0) return 0;
+    return requiredFreeArea(cfm, faceVelocity) / freeAreaRatio;
+}
+
+/*
+Return sizing is where DIY systems fail most often, so the
+app gives it its own answer: the return path has to carry
+the entire blower airflow, not one room's worth.
+*/
+export function returnPlan(totalCfm, { faceVelocity = 400, grilleType = 'stamped', materialFactor = 1, rate = 0.08 } = {}) {
+    const freeArea = GRILLE_TYPES[grilleType].freeArea;
+    const faceArea = requiredGrilleFaceArea(totalCfm, faceVelocity, freeArea);
+    const diameter = requiredDiameter(totalCfm, rate, materialFactor);
+
+    return {
+        faceAreaSqIn: faceArea,
+        faceAreaSqFt: faceArea / 144,
+        singleGrille: squareSideFor(faceArea),
+        twoGrilles: squareSideFor(faceArea / 2),
+        ductDiameter: diameter,
+        nominalDuct: nextRoundSize(diameter),
+        equivalentDe: diameter,
+    };
+}
+
+function squareSideFor(areaSqIn) {
+    return Math.ceil(Math.sqrt(Math.max(0, areaSqIn)) / 2) * 2;
+}
+
+/*
+---------------------------------------------------
+TRUNK REDUCTION
+---------------------------------------------------
+Walk the trunk from the plenum outward, subtracting each
+branch as it peels off, and resize when the remaining air
+no longer needs the section it is in. Two rules keep it
+practical: reduce in 2" steps, and stop at 8" — smaller
+trunks cost more in fittings than they save in metal.
+*/
+export function reduceTrunk(startCfm, branches, rate, materialFactor = 1, minDepth = 8) {
+    let remaining = startCfm;
+
+    return branches.map((branch) => {
+        const before = remaining;
+        remaining = Math.max(0, remaining - branch.cfm);
+        const de = requiredDiameter(remaining, rate, materialFactor);
+
+        return {
+            ...branch,
+            cfmBefore: before,
+            cfmAfter: remaining,
+            requiredDe: de,
+            nominalRound: remaining > 0 ? nextRoundSize(de) : 0,
+            keepDepth: Math.max(minDepth, 0),
+        };
+    });
+}

--- a/src/_hvac/lib/ductMath.test.js
+++ b/src/_hvac/lib/ductMath.test.js
@@ -1,0 +1,138 @@
+/*
+Checks the math against numbers you can look up on a real
+ductulator or in the ASHRAE equivalent-diameter table.
+Run with: npm test
+*/
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    availableStaticPressure,
+    cfmAtSize,
+    distributeCfm,
+    equivalentDiameter,
+    frictionPer100ft,
+    frictionRate,
+    gradeAspectRatio,
+    gradeVelocity,
+    nextRoundSize,
+    reduceTrunk,
+    requiredDiameter,
+    requiredFreeArea,
+    returnPlan,
+    roundVelocity,
+    systemCfm,
+    widthForEquivalentDiameter,
+} from './ductMath.js';
+
+import { STARTER_SELECTIONS, totalEffectiveLength } from './fittings.js';
+
+const close = (actual, expected, tolerance) =>
+    assert.ok(Math.abs(actual - expected) <= tolerance, `${actual} is not within ${tolerance} of ${expected}`);
+
+/* Ductulator spot checks at the classic 0.10 in.wc / 100 ft. */
+test('capacity at 0.10 friction matches a ductulator', () => {
+    close(cfmAtSize(6, 0.1), 109, 4);
+    close(cfmAtSize(8, 0.1), 227, 8);
+    close(cfmAtSize(10, 0.1), 419, 12);
+    close(cfmAtSize(12, 0.1), 679, 20);
+});
+
+test('requiredDiameter inverts frictionPer100ft', () => {
+    const diameter = requiredDiameter(600, 0.09);
+    close(frictionPer100ft(600, diameter), 0.09, 0.0001);
+});
+
+test('rougher material demands a bigger duct', () => {
+    assert.ok(requiredDiameter(400, 0.08, 1.5) > requiredDiameter(400, 0.08, 1.0));
+});
+
+test('nextRoundSize never rounds down', () => {
+    assert.equal(nextRoundSize(9.83), 10);
+    assert.equal(nextRoundSize(10), 10);
+    assert.equal(nextRoundSize(10.01), 12);
+});
+
+/* ASHRAE equivalent round duct table: 12x12 -> 13.1, 8x20 -> 13.5 */
+test('equivalent diameter matches the published table', () => {
+    close(equivalentDiameter(12, 12), 13.1, 0.1);
+    close(equivalentDiameter(20, 8), 13.5, 0.1);
+});
+
+test('widthForEquivalentDiameter round-trips', () => {
+    const de = equivalentDiameter(20, 8);
+    close(widthForEquivalentDiameter(8, de), 20, 0.05);
+});
+
+test('velocity in a 10 inch pipe at 400 cfm is about 733 fpm', () => {
+    close(roundVelocity(400, 10), 733, 2);
+});
+
+test('airflow presets', () => {
+    assert.equal(systemCfm(2.5, 400), 1000);
+    assert.equal(systemCfm(3, 350), 1050);
+});
+
+test('room airflow splits by area weighted by exposure and sums to the total', () => {
+    const rooms = [
+        { name: 'Living', area: 300, exposure: 1.35 },
+        { name: 'Bed', area: 150, exposure: 1.15 },
+        { name: 'Hall', area: 100, exposure: 1.0 },
+    ];
+    const result = distributeCfm(rooms, 1000);
+    const sum = result.reduce((total, room) => total + room.cfm, 0);
+
+    close(sum, 1000, 3);
+    assert.ok(result[0].cfm > result[1].cfm, 'the big exposed room gets the most air');
+});
+
+test('pressure budget subtracts every component in the airstream', () => {
+    const { spent, available } = availableStaticPressure(0.7, { coil: 0.25, filter: 0.15, registers: 0.03 });
+    close(spent, 0.43, 1e-9);
+    close(available, 0.27, 1e-9);
+});
+
+test('friction rate is pressure spread over effective length', () => {
+    close(frictionRate(0.25, 250), 0.1, 1e-9);
+    assert.equal(frictionRate(0.25, 0), 0);
+});
+
+test('the starter fitting kit lands on a normal friction rate', () => {
+    const tel = totalEffectiveLength({ supplyRun: 40, returnRun: 25, selections: STARTER_SELECTIONS });
+    const rate = frictionRate(0.27, tel.total);
+
+    assert.equal(tel.fittings, 35 + 30 + 35 + 60 + 30 + 20);
+    assert.ok(rate > 0.06 && rate < 0.18, `rate ${rate} should be in the workable band`);
+});
+
+test('velocity grading flags noise and lazy air', () => {
+    assert.equal(gradeVelocity(1200, 'supplyTrunk').level, 'bad');
+    assert.equal(gradeVelocity(800, 'supplyTrunk').level, 'good');
+    assert.equal(gradeVelocity(300, 'supplyBranch').level, 'warn');
+});
+
+test('aspect ratio grading', () => {
+    assert.equal(gradeAspectRatio(1.5).level, 'good');
+    assert.equal(gradeAspectRatio(3).level, 'warn');
+    assert.equal(gradeAspectRatio(5).level, 'bad');
+});
+
+test('return grille free area follows the 400 fpm rule of thumb', () => {
+    /* 400 cfm at 400 fpm needs one square foot of net free area. */
+    close(requiredFreeArea(400, 400), 144, 0.5);
+});
+
+test('return plan sizes for the whole blower, not one room', () => {
+    const plan = returnPlan(1200, { faceVelocity: 400, grilleType: 'stamped', rate: 0.08 });
+    assert.ok(plan.faceAreaSqFt > 4, 'a 1200 cfm return needs serious face area');
+    assert.ok(plan.nominalDuct >= 16);
+    assert.ok(plan.twoGrilles < plan.singleGrille);
+});
+
+test('trunk reduction subtracts each branch as it peels off', () => {
+    const steps = reduceTrunk(1200, [{ cfm: 300 }, { cfm: 300 }, { cfm: 300 }], 0.08);
+
+    assert.equal(steps[0].cfmAfter, 900);
+    assert.equal(steps[2].cfmAfter, 300);
+    assert.ok(steps[0].nominalRound > steps[2].nominalRound, 'the trunk gets smaller downstream');
+});

--- a/src/_hvac/lib/fittings.js
+++ b/src/_hvac/lib/fittings.js
@@ -1,0 +1,111 @@
+/*
+===================================================
+FITTING EQUIVALENT LENGTHS
+===================================================
+A fitting does not cost you inches, it costs you feet.
+Every elbow, tee, boot and takeoff is converted into the
+length of straight duct that would lose the same pressure,
+then added to the tape-measure length. The sum is Total
+Effective Length (TEL).
+
+Values below are rounded, representative numbers in the
+spirit of ACCA Manual D Appendix 3. They are correct enough
+to size a house and to build the right instincts. Pull the
+real tables if you are stamping drawings.
+*/
+
+export const FITTING_GROUPS = [
+    {
+        id: 'departure',
+        title: 'Leaving the equipment',
+        fittings: [
+            { id: 'plenum-takeoff-angled', label: 'Angled / 45° takeoff off the plenum', ef: 35 },
+            { id: 'plenum-takeoff-square', label: 'Square 90° takeoff off the plenum', ef: 55 },
+            { id: 'plenum-takeoff-bellmouth', label: 'Bellmouth or conical takeoff', ef: 15 },
+            { id: 'trunk-takeoff-angled', label: 'Angled takeoff off the side of a trunk', ef: 35 },
+            { id: 'trunk-takeoff-square', label: 'Square takeoff off the side of a trunk', ef: 50 },
+            { id: 'trunk-takeoff-bottom', label: 'Takeoff out the bottom of a trunk', ef: 65 },
+        ],
+    },
+    {
+        id: 'turns',
+        title: 'Turns',
+        fittings: [
+            { id: 'elbow-45', label: '45° elbow, round', ef: 10 },
+            { id: 'elbow-90-smooth', label: '90° elbow, round, long radius', ef: 15 },
+            { id: 'elbow-90-adjustable', label: '90° elbow, round, adjustable (gored)', ef: 20 },
+            { id: 'elbow-90-flex', label: '90° bend in flex duct, generous radius', ef: 25 },
+            { id: 'elbow-90-flex-tight', label: '90° bend in flex duct, tight radius', ef: 50 },
+            { id: 'elbow-90-rect-vanes', label: '90° rectangular elbow with turning vanes', ef: 15 },
+            { id: 'elbow-90-rect-plain', label: '90° rectangular elbow, no vanes', ef: 45 },
+        ],
+    },
+    {
+        id: 'splits',
+        title: 'Splits and transitions',
+        fittings: [
+            { id: 'wye', label: 'Wye fitting (branch leg)', ef: 25 },
+            { id: 'tee', label: 'Straight tee (branch leg)', ef: 40 },
+            { id: 'trunk-reducer', label: 'Trunk reduction fitting', ef: 10 },
+            { id: 'transition', label: 'Round-to-rectangular transition', ef: 10 },
+        ],
+    },
+    {
+        id: 'arrival',
+        title: 'Arriving at the room',
+        fittings: [
+            { id: 'boot-straight', label: 'Straight boot into a register', ef: 35 },
+            { id: 'boot-90', label: 'Boot with a 90° turn (stud or joist boot)', ef: 60 },
+            { id: 'boot-end', label: 'End boot, air turns 90° and stops', ef: 70 },
+        ],
+    },
+    {
+        id: 'return',
+        title: 'On the return side',
+        fittings: [
+            { id: 'return-grille-box', label: 'Return grille and box', ef: 30 },
+            { id: 'return-filter-grille', label: 'Filter-back return grille and box', ef: 60 },
+            { id: 'panned-joist', label: 'Panned joist bay used as return (do not)', ef: 90 },
+            { id: 'return-drop', label: 'Return drop into the equipment', ef: 20 },
+        ],
+    },
+];
+
+export const ALL_FITTINGS = FITTING_GROUPS.flatMap((group) => group.fittings);
+
+export function findFitting(id) {
+    return ALL_FITTINGS.find((fitting) => fitting.id === id);
+}
+
+/*
+TEL is measured along ONE path: the longest supply run plus
+the longest return run. Not the total of all duct in the
+house — a mistake that produces absurdly small friction
+rates and comically oversized ducts.
+*/
+export function totalEffectiveLength({ supplyRun = 0, returnRun = 0, selections = {} }) {
+    const fittingLength = Object.entries(selections).reduce((sum, [id, count]) => {
+        const fitting = findFitting(id);
+        return fitting ? sum + fitting.ef * (Number(count) || 0) : sum;
+    }, 0);
+
+    return {
+        measured: supplyRun + returnRun,
+        fittings: fittingLength,
+        total: supplyRun + returnRun + fittingLength,
+    };
+}
+
+/*
+A starting kit for someone who has never done this. It is a
+believable single-trunk basement system and it lands on a
+friction rate in the normal range, which is the point.
+*/
+export const STARTER_SELECTIONS = {
+    'plenum-takeoff-angled': 1,
+    'elbow-90-smooth': 2,
+    'trunk-takeoff-angled': 1,
+    'boot-90': 1,
+    'return-grille-box': 1,
+    'return-drop': 1,
+};

--- a/src/_hvac/styles.scss
+++ b/src/_hvac/styles.scss
@@ -1,0 +1,1141 @@
+/*
+===================================================
+HVAC APPLET STYLES
+===================================================
+Self-contained on purpose. The applet ships its own small
+stylesheet instead of pulling in the site bundle, so /hvac
+loads two files and nothing else.
+
+Tokens follow the portfolio palette and honour the same
+data-theme attribute the rest of the site uses, so arriving
+from the site does not flash a different look.
+*/
+
+:root {
+    --ink: #24282c;
+    --ink-soft: #5c6166;
+    --ink-faint: #8a9096;
+    --paper: #f3f3f3;
+    --card: #ffffff;
+    --line: #dcdcdc;
+    --line-soft: #ebebeb;
+    --accent: #2863a1;
+    --accent-soft: #e8f0f9;
+    --good: #1f7a4d;
+    --good-soft: #e6f4ec;
+    --warn: #9a5a00;
+    --warn-soft: #fdf1de;
+    --bad: #a32b26;
+    --bad-soft: #fbeae9;
+    --secret: #6b3fa0;
+    --secret-soft: #f1ebfa;
+
+    --radius: 8px;
+    --radius-lg: 14px;
+    --shadow: 0 1px 2px rgba(0, 0, 0, 0.06), 0 6px 20px rgba(0, 0, 0, 0.05);
+
+    --sans: 'Rethink Sans', 'Fira Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    --mono: 'Space Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+}
+
+@mixin dark-tokens {
+    --ink: #eceff1;
+    --ink-soft: #adb3b8;
+    --ink-faint: #7d848a;
+    --paper: #131517;
+    --card: #1c1f22;
+    --line: #2f3438;
+    --line-soft: #262a2d;
+    --accent: #63b3ed;
+    --accent-soft: #1b2c3d;
+    --good: #6ddc9f;
+    --good-soft: #16281f;
+    --warn: #f0b45f;
+    --warn-soft: #2c2214;
+    --bad: #f08a84;
+    --bad-soft: #2e1a19;
+    --secret: #c4a6ef;
+    --secret-soft: #241d33;
+    --shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 6px 20px rgba(0, 0, 0, 0.3);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        @include dark-tokens;
+    }
+}
+
+html[data-theme='dark'] {
+    @include dark-tokens;
+}
+
+html[data-theme='light'] {
+    color-scheme: light;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 17px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+}
+
+h1,
+h2,
+h3,
+h4 {
+    margin: 0;
+    line-height: 1.25;
+    font-weight: 700;
+    letter-spacing: -0.015em;
+}
+
+p {
+    margin: 0 0 1em;
+}
+
+a {
+    color: var(--accent);
+}
+
+/*
+---------------------------------------------------
+SHELL
+---------------------------------------------------
+*/
+
+.app {
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 0 1.25rem 4rem;
+}
+
+.masthead {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1.5rem;
+    padding: 2.5rem 0 2rem;
+    border-bottom: 1px solid var(--line);
+
+    h1 {
+        font-size: clamp(1.9rem, 4.5vw, 2.75rem);
+        margin-bottom: 0.5rem;
+    }
+}
+
+.masthead__eyebrow {
+    margin: 0 0 0.35rem;
+    font-family: var(--mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--accent);
+}
+
+.masthead__tagline {
+    max-width: 62ch;
+    margin: 0;
+    color: var(--ink-soft);
+}
+
+.masthead__home {
+    flex: none;
+    font-family: var(--mono);
+    font-size: 0.8rem;
+    text-decoration: none;
+    white-space: nowrap;
+
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
+.layout {
+    display: grid;
+    grid-template-columns: 208px minmax(0, 1fr);
+    gap: 2.5rem;
+    align-items: start;
+    padding-top: 2rem;
+}
+
+.layout__nav {
+    position: sticky;
+    top: 1.5rem;
+}
+
+.layout__main {
+    min-width: 0;
+}
+
+/*
+---------------------------------------------------
+NAVIGATION
+---------------------------------------------------
+*/
+
+.nav__group + .nav__group {
+    margin-top: 1.5rem;
+}
+
+.nav__title {
+    margin: 0 0 0.5rem;
+    font-family: var(--mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+}
+
+.nav ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.nav__link {
+    display: block;
+    width: 100%;
+    padding: 0.4rem 0.6rem;
+    border: 0;
+    border-left: 2px solid var(--line);
+    border-radius: 0 var(--radius) var(--radius) 0;
+    background: none;
+    color: var(--ink-soft);
+    font: inherit;
+    font-size: 0.92rem;
+    text-align: left;
+    cursor: pointer;
+
+    &:hover {
+        background: var(--line-soft);
+        color: var(--ink);
+    }
+}
+
+.nav__link--active {
+    border-left-color: var(--accent);
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-weight: 600;
+}
+
+/*
+---------------------------------------------------
+WORKSHEET STRIP
+---------------------------------------------------
+*/
+
+.worksheet {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+    flex-wrap: wrap;
+    margin-bottom: 2rem;
+    padding: 0.9rem 1.1rem;
+    border: 1px solid var(--line);
+    border-left: 3px solid var(--accent);
+    border-radius: var(--radius);
+    background: var(--card);
+
+    dl {
+        display: flex;
+        flex: 1;
+        flex-wrap: wrap;
+        gap: 0.35rem 1.75rem;
+        margin: 0;
+    }
+
+    dt {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+    }
+
+    dd {
+        margin: 0;
+        font-family: var(--mono);
+        font-size: 1rem;
+        font-weight: 700;
+    }
+}
+
+.worksheet--warn {
+    border-left-color: var(--warn);
+}
+
+.worksheet--bad {
+    border-left-color: var(--bad);
+}
+
+.worksheet__title {
+    margin: 0;
+    font-family: var(--mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+}
+
+/*
+---------------------------------------------------
+LESSON BODY
+---------------------------------------------------
+*/
+
+.lesson__header {
+    margin-bottom: 2rem;
+
+    h2 {
+        font-size: clamp(1.5rem, 3.5vw, 2.1rem);
+        margin-bottom: 0.5rem;
+    }
+}
+
+.lesson__step {
+    margin: 0 0 0.4rem;
+    font-family: var(--mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent);
+}
+
+.lesson__subtitle {
+    max-width: 68ch;
+    margin: 0;
+    font-size: 1.08rem;
+    color: var(--ink-soft);
+}
+
+.prose {
+    max-width: 72ch;
+
+    > div + div {
+        margin-top: 0.25rem;
+    }
+}
+
+.prose__heading {
+    margin: 2rem 0 0.75rem;
+    font-size: 1.15rem;
+}
+
+.prose__list,
+.prose__steps {
+    margin: 0 0 1em;
+    padding-left: 1.35rem;
+
+    li + li {
+        margin-top: 0.45rem;
+    }
+}
+
+.prose__steps li {
+    padding-left: 0.25rem;
+}
+
+/*
+---------------------------------------------------
+CALLOUTS
+---------------------------------------------------
+*/
+
+.callout {
+    margin: 1.5rem 0;
+    padding: 1rem 1.15rem;
+    border-radius: var(--radius);
+    border-left: 3px solid;
+
+    p {
+        margin: 0;
+    }
+}
+
+.callout__kind {
+    font-family: var(--mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    opacity: 0.85;
+}
+
+.callout__title {
+    margin-top: 0.2rem !important;
+    font-weight: 700;
+}
+
+.callout__body {
+    margin-top: 0.35rem !important;
+    color: var(--ink-soft);
+}
+
+.callout--secret {
+    border-left-color: var(--secret);
+    background: var(--secret-soft);
+
+    .callout__kind {
+        color: var(--secret);
+    }
+}
+
+.callout--tip {
+    border-left-color: var(--accent);
+    background: var(--accent-soft);
+
+    .callout__kind {
+        color: var(--accent);
+    }
+}
+
+.callout--warn {
+    border-left-color: var(--bad);
+    background: var(--bad-soft);
+
+    .callout__kind {
+        color: var(--bad);
+    }
+}
+
+/*
+---------------------------------------------------
+FORMULA
+---------------------------------------------------
+*/
+
+.formula {
+    margin: 1.5rem 0;
+    padding: 1.1rem 1.25rem;
+    border: 1px dashed var(--line);
+    border-radius: var(--radius);
+    background: var(--card);
+}
+
+.formula__expression {
+    margin: 0;
+    font-family: var(--mono);
+    font-size: 0.95rem;
+    font-weight: 700;
+}
+
+.formula__legend {
+    margin: 0.75rem 0 0;
+    padding-left: 1.1rem;
+    font-size: 0.9rem;
+    color: var(--ink-soft);
+
+    li + li {
+        margin-top: 0.3rem;
+    }
+}
+
+/*
+---------------------------------------------------
+TABLES
+---------------------------------------------------
+*/
+
+.table-scroll {
+    overflow-x: auto;
+    margin: 1.25rem 0;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    background: var(--card);
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.92rem;
+}
+
+th,
+td {
+    padding: 0.6rem 0.8rem;
+    text-align: left;
+    vertical-align: middle;
+    border-bottom: 1px solid var(--line-soft);
+}
+
+th {
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    white-space: nowrap;
+}
+
+tbody tr:last-child td {
+    border-bottom: 0;
+}
+
+.numeric {
+    text-align: right;
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+}
+
+.strong {
+    font-weight: 700;
+}
+
+.muted {
+    color: var(--ink-faint);
+}
+
+.small {
+    font-size: 0.82rem;
+}
+
+.cell--good {
+    color: var(--good);
+}
+
+.cell--warn {
+    color: var(--warn);
+}
+
+.cell--bad {
+    color: var(--bad);
+}
+
+.reference td.numeric,
+.reference th.numeric {
+    min-width: 4.5rem;
+}
+
+/*
+---------------------------------------------------
+PANELS AND FORMS
+---------------------------------------------------
+*/
+
+.panel {
+    margin: 2rem 0;
+    padding: 1.35rem 1.5rem 1.5rem;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-lg);
+    background: var(--card);
+    box-shadow: var(--shadow);
+}
+
+.panel__header {
+    margin-bottom: 1.25rem;
+
+    h3 {
+        font-size: 1.1rem;
+    }
+
+    p {
+        max-width: 70ch;
+        margin: 0.35rem 0 0;
+        font-size: 0.93rem;
+        color: var(--ink-soft);
+    }
+}
+
+.panel__subhead {
+    margin: 1.75rem 0 0.5rem;
+    font-size: 0.95rem;
+}
+
+.panel__footnote,
+.panel__note {
+    margin: 0.75rem 0 0;
+    font-size: 0.86rem;
+    color: var(--ink-faint);
+}
+
+.panel__note {
+    font-size: 0.93rem;
+    color: var(--ink-soft);
+}
+
+.fields {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+
+    &[data-columns='1'] {
+        grid-template-columns: minmax(0, 420px);
+    }
+}
+
+.field {
+    display: block;
+    min-width: 0;
+}
+
+.field__label:not(:empty) {
+    display: block;
+    margin-bottom: 0.3rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: var(--ink-soft);
+}
+
+.field__control {
+    display: flex;
+    align-items: stretch;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    background: var(--paper);
+    overflow: hidden;
+
+    &:focus-within {
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--accent-soft);
+    }
+}
+
+input,
+select {
+    flex: 1;
+    min-width: 0;
+    padding: 0.5rem 0.65rem;
+    border: 0;
+    background: transparent;
+    color: var(--ink);
+    font: inherit;
+    font-size: 0.94rem;
+
+    &:focus {
+        outline: none;
+    }
+}
+
+select {
+    cursor: pointer;
+}
+
+.field__suffix {
+    display: flex;
+    align-items: center;
+    padding: 0 0.7rem;
+    border-left: 1px solid var(--line);
+    background: var(--line-soft);
+    font-family: var(--mono);
+    font-size: 0.8rem;
+    color: var(--ink-faint);
+    white-space: nowrap;
+}
+
+.field__hint {
+    display: block;
+    margin-top: 0.3rem;
+    font-size: 0.8rem;
+    color: var(--ink-faint);
+}
+
+.button {
+    display: inline-block;
+    padding: 0.5rem 0.95rem;
+    border: 1px solid var(--accent);
+    border-radius: var(--radius);
+    background: var(--accent);
+    color: var(--card);
+    font: inherit;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+
+    &:hover {
+        filter: brightness(1.08);
+    }
+}
+
+.button--quiet {
+    border-color: var(--line);
+    background: transparent;
+    color: var(--ink-soft);
+
+    &:hover {
+        background: var(--line-soft);
+        filter: none;
+    }
+}
+
+/*
+---------------------------------------------------
+RESULTS
+---------------------------------------------------
+*/
+
+.stat-row {
+    display: grid;
+    gap: 0.9rem;
+    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+    margin: 1.25rem 0;
+}
+
+.stat {
+    padding: 0.8rem 0.95rem;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    background: var(--paper);
+}
+
+.stat__label {
+    margin: 0;
+    font-size: 0.72rem;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+}
+
+.stat__value {
+    margin: 0.2rem 0 0;
+    font-family: var(--mono);
+    font-size: 1.45rem;
+    font-weight: 700;
+    line-height: 1.15;
+}
+
+.stat__unit {
+    margin-left: 0.3rem;
+    font-size: 0.78rem;
+    font-weight: 400;
+    color: var(--ink-faint);
+}
+
+.stat__hint {
+    margin: 0.35rem 0 0;
+    font-size: 0.8rem;
+    line-height: 1.4;
+    color: var(--ink-soft);
+}
+
+.stat--primary {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+
+    .stat__value {
+        color: var(--accent);
+    }
+}
+
+.stat--good {
+    border-color: var(--good);
+    background: var(--good-soft);
+
+    .stat__value {
+        color: var(--good);
+    }
+}
+
+.stat--warn {
+    border-color: var(--warn);
+    background: var(--warn-soft);
+
+    .stat__value {
+        color: var(--warn);
+    }
+}
+
+.stat--bad {
+    border-color: var(--bad);
+    background: var(--bad-soft);
+
+    .stat__value {
+        color: var(--bad);
+    }
+}
+
+.verdict {
+    margin: 0.75rem 0 0;
+    padding: 0.6rem 0.85rem;
+    border-radius: var(--radius);
+    font-size: 0.9rem;
+}
+
+.verdict--good {
+    background: var(--good-soft);
+    color: var(--good);
+}
+
+.verdict--warn {
+    background: var(--warn-soft);
+    color: var(--warn);
+}
+
+.verdict--bad {
+    background: var(--bad-soft);
+    color: var(--bad);
+}
+
+/*
+---------------------------------------------------
+FITTING COUNTERS
+---------------------------------------------------
+*/
+
+.fitting-group {
+    margin-bottom: 1.5rem;
+
+    h4 {
+        margin-bottom: 0.5rem;
+        font-size: 0.72rem;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--ink-faint);
+    }
+}
+
+.fitting {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto 4.5rem;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid var(--line-soft);
+}
+
+.fitting__label {
+    margin: 0;
+    font-size: 0.92rem;
+}
+
+.fitting__cost {
+    margin: 0;
+    font-size: 0.78rem;
+    color: var(--ink-faint);
+}
+
+.fitting__total {
+    margin: 0;
+    font-family: var(--mono);
+    font-size: 0.88rem;
+    font-weight: 700;
+    text-align: right;
+    color: var(--ink-soft);
+}
+
+.stepper {
+    display: flex;
+    align-items: center;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    overflow: hidden;
+
+    button {
+        width: 2rem;
+        padding: 0.3rem 0;
+        border: 0;
+        background: var(--paper);
+        color: var(--ink-soft);
+        font: inherit;
+        font-size: 1rem;
+        cursor: pointer;
+
+        &:hover {
+            background: var(--line-soft);
+            color: var(--ink);
+        }
+    }
+}
+
+.stepper__count {
+    min-width: 2rem;
+    text-align: center;
+    font-family: var(--mono);
+    font-size: 0.9rem;
+    color: var(--ink-faint);
+}
+
+.stepper__count--active {
+    font-weight: 700;
+    color: var(--accent);
+}
+
+/* Inputs sit inside table cells on the room and ledger tables. */
+.room-table,
+.ledger {
+    .field__control {
+        background: var(--paper);
+    }
+
+    td {
+        min-width: 7rem;
+    }
+}
+
+/*
+---------------------------------------------------
+SECRETS
+---------------------------------------------------
+*/
+
+.secrets__group {
+    margin-bottom: 2.25rem;
+
+    h3 {
+        padding-bottom: 0.4rem;
+        border-bottom: 1px solid var(--line);
+        font-size: 0.75rem;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--accent);
+    }
+
+    ol {
+        margin: 1rem 0 0;
+        padding-left: 1.4rem;
+    }
+
+    li + li {
+        margin-top: 1.1rem;
+    }
+}
+
+.secrets__rule {
+    margin: 0;
+    font-weight: 700;
+}
+
+.secrets__why {
+    max-width: 70ch;
+    margin: 0.25rem 0 0;
+    font-size: 0.93rem;
+    color: var(--ink-soft);
+}
+
+/*
+---------------------------------------------------
+QUIZ
+---------------------------------------------------
+*/
+
+.quiz__score {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    background: var(--card);
+
+    p {
+        margin: 0;
+        font-family: var(--mono);
+        font-size: 0.95rem;
+    }
+}
+
+.quiz__item {
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--line);
+
+    h3 {
+        display: flex;
+        gap: 0.6rem;
+        max-width: 68ch;
+        font-size: 1.05rem;
+    }
+}
+
+.quiz__number {
+    flex: none;
+    font-family: var(--mono);
+    color: var(--ink-faint);
+}
+
+.quiz__options {
+    margin: 0.9rem 0 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 0.5rem;
+    max-width: 62ch;
+}
+
+.quiz__option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    width: 100%;
+    padding: 0.6rem 0.85rem;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    background: var(--card);
+    color: var(--ink);
+    font: inherit;
+    font-size: 0.93rem;
+    text-align: left;
+    cursor: pointer;
+
+    &:hover:enabled {
+        border-color: var(--accent);
+    }
+
+    &:disabled {
+        cursor: default;
+    }
+}
+
+.quiz__option--correct {
+    border-color: var(--good);
+    background: var(--good-soft);
+    color: var(--good);
+    font-weight: 600;
+}
+
+.quiz__option--wrong {
+    border-color: var(--bad);
+    background: var(--bad-soft);
+    color: var(--bad);
+}
+
+.quiz__mark {
+    flex: none;
+    font-family: var(--mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    opacity: 0.8;
+}
+
+.quiz__explanation {
+    max-width: 70ch;
+    margin: 0.9rem 0 0;
+    padding-left: 0.9rem;
+    border-left: 2px solid var(--line);
+    font-size: 0.92rem;
+    color: var(--ink-soft);
+}
+
+/*
+---------------------------------------------------
+PAGER AND FOOTER
+---------------------------------------------------
+*/
+
+.pager {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--line);
+}
+
+.site-footer {
+    max-width: 78ch;
+    margin: 3rem auto 0;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--line);
+
+    p {
+        margin: 0;
+        font-size: 0.84rem;
+        color: var(--ink-faint);
+    }
+}
+
+/*
+---------------------------------------------------
+RESPONSIVE
+---------------------------------------------------
+*/
+
+@media (max-width: 860px) {
+    .layout {
+        grid-template-columns: minmax(0, 1fr);
+        gap: 1.5rem;
+    }
+
+    .layout__nav {
+        position: static;
+        overflow-x: auto;
+        padding-bottom: 0.5rem;
+    }
+
+    /* Flatten the groups into one scrolling strip of links. Group headings
+       would scroll out of view horizontally and leave a puzzling gap. */
+    .nav {
+        display: flex;
+        gap: 0.35rem;
+    }
+
+    .nav__group {
+        display: contents;
+    }
+
+    .nav__title {
+        display: none;
+    }
+
+    .nav ul {
+        display: flex;
+        gap: 0.35rem;
+    }
+
+    .nav__link {
+        border-left: 0;
+        border-bottom: 2px solid var(--line);
+        border-radius: var(--radius) var(--radius) 0 0;
+        white-space: nowrap;
+    }
+
+    .nav__link--active {
+        border-bottom-color: var(--accent);
+    }
+
+    .masthead {
+        flex-direction: column-reverse;
+        align-items: flex-start;
+        gap: 0.75rem;
+        padding-top: 1.5rem;
+    }
+
+    /* Two-by-two figures under a title row, instead of one tall column. */
+    .worksheet {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 0.6rem 0.75rem;
+
+        .worksheet__title {
+            grid-area: 1 / 1;
+        }
+
+        .button {
+            grid-area: 1 / 2;
+        }
+
+        dl {
+            display: grid;
+            grid-area: 2 / 1 / 3 / -1;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 0.6rem 1rem;
+        }
+    }
+
+    .panel {
+        padding: 1.1rem 1rem 1.25rem;
+    }
+
+    .fitting {
+        grid-template-columns: minmax(0, 1fr) auto;
+        row-gap: 0.35rem;
+    }
+
+    .fitting__total {
+        grid-column: 2;
+        text-align: right;
+    }
+}

--- a/src/_hvac/views/Quiz.jsx
+++ b/src/_hvac/views/Quiz.jsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+
+import { QUIZ } from '../data/quiz.js';
+
+/*
+Answer-immediately quiz. Showing the explanation the moment a
+choice is made — right or wrong — teaches more than a score at
+the end, so there is no submit button and no timer.
+*/
+
+export function Quiz() {
+    const [answers, setAnswers] = useState({});
+
+    const choose = (questionIndex, optionIndex) => {
+        if (answers[questionIndex] !== undefined) return; /* one shot per question */
+        setAnswers({ ...answers, [questionIndex]: optionIndex });
+    };
+
+    const answered = Object.keys(answers).length;
+    const correct = Object.entries(answers).filter(([index, choice]) => QUIZ[index].answer === choice).length;
+
+    return (
+        <div className="quiz">
+            <div className="quiz__score">
+                <p>
+                    <strong>{correct}</strong> of {answered} correct
+                    {answered < QUIZ.length && <span className="muted"> · {QUIZ.length - answered} to go</span>}
+                </p>
+                {answered > 0 && (
+                    <button type="button" className="button button--quiet" onClick={() => setAnswers({})}>
+                        Start over
+                    </button>
+                )}
+            </div>
+
+            {QUIZ.map((item, questionIndex) => {
+                const choice = answers[questionIndex];
+                const isAnswered = choice !== undefined;
+
+                return (
+                    <section key={item.question} className="quiz__item">
+                        <h3>
+                            <span className="quiz__number">{questionIndex + 1}</span>
+                            {item.question}
+                        </h3>
+
+                        <ul className="quiz__options">
+                            {item.options.map((option, optionIndex) => {
+                                const isCorrect = optionIndex === item.answer;
+                                const isChosen = optionIndex === choice;
+
+                                let state = 'idle';
+                                if (isAnswered && isCorrect) state = 'correct';
+                                else if (isChosen) state = 'wrong';
+
+                                return (
+                                    <li key={option}>
+                                        <button
+                                            type="button"
+                                            className={`quiz__option quiz__option--${state}`}
+                                            onClick={() => choose(questionIndex, optionIndex)}
+                                            disabled={isAnswered}
+                                        >
+                                            {option}
+                                            {isAnswered && isCorrect && <span className="quiz__mark">correct</span>}
+                                            {isChosen && !isCorrect && <span className="quiz__mark">your answer</span>}
+                                        </button>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+
+                        {isAnswered && <p className="quiz__explanation">{item.explanation}</p>}
+                    </section>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/_hvac/views/Secrets.jsx
+++ b/src/_hvac/views/Secrets.jsx
@@ -1,0 +1,27 @@
+import { SECRET_GROUPS } from '../data/secrets.js';
+
+/*
+The whole cheat sheet on one scrollable page, so it can be
+read on a phone while lying in a crawlspace. Every item is a
+rule plus the reason — the reason is what makes it stick.
+*/
+
+export function Secrets() {
+    return (
+        <div className="secrets">
+            {SECRET_GROUPS.map((group) => (
+                <section key={group.title} className="secrets__group">
+                    <h3>{group.title}</h3>
+                    <ol>
+                        {group.secrets.map((secret) => (
+                            <li key={secret.rule}>
+                                <p className="secrets__rule">{secret.rule}</p>
+                                <p className="secrets__why">{secret.why}</p>
+                            </li>
+                        ))}
+                    </ol>
+                </section>
+            ))}
+        </div>
+    );
+}

--- a/src/_layouts/hvac.njk
+++ b/src/_layouts/hvac.njk
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="generator" content="{{ eleventy.generator }}" />
+    <title>{{ title }} | {{ meta.siteName }}</title>
+    <meta name="description" content="{{ description }}">
+    <link rel="canonical" href="{{ meta.url }}{{ page.url }}">
+
+    <meta property="og:url" content="{{ meta.url }}{{ page.url }}">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="{{ title }}">
+    <meta property="og:description" content="{{ description }}">
+    <meta property="og:image" content="{{ meta.url }}/assets/og_image.png">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌬️</text></svg>">
+
+    {# The applet ships its own stylesheet rather than the site bundle, so this
+       route stays light. Fonts are shared with the site so they are already cached. #}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Space+Mono&family=Rethink+Sans:wght@400..800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/assets/css/hvac.css">
+
+    <script>
+      // Match the theme the rest of the site is using, before first paint.
+      (function () {
+        var stored = sessionStorage.getItem('theme');
+        if (stored) document.documentElement.setAttribute('data-theme', stored);
+      })();
+    </script>
+</head>
+<body>
+    <div id="hvac-root">
+        {# Rendered before React mounts and replaced on hydrate — search engines and
+           no-JS visitors still get the premise and a way back to the site. #}
+        <noscript>
+            <h1>Duct Sizing for DIYers</h1>
+            <p>This interactive guide needs JavaScript enabled.</p>
+            <p><a href="/">Back to derekonay.com</a></p>
+        </noscript>
+    </div>
+    <script src="/assets/js/hvac.js"></script>
+</body>
+</html>

--- a/src/hvac.njk
+++ b/src/hvac.njk
@@ -1,0 +1,7 @@
+---
+title: Duct Sizing for DIYers
+description: An interactive guide to sizing and installing HVAC ductwork — the real method professionals use, plus the shortcuts they never write down.
+layout: hvac.njk
+permalink: /hvac/index.html
+eleventyExcludeFromCollections: true
+---


### PR DESCRIPTION
A self-contained React applet that teaches an amateur DIYer how to size
and install ductwork, structured as the eight steps a professional
actually follows: airflow, pressure budget, effective length, duct
sizing, returns, layout, installation craft, and verification.

The worksheet carries through all eight steps — entering room areas in
step 1 changes the duct schedule in step 4 — so the chain from equipment
to duct size is visible rather than described. Expert-secret callouts
throughout capture the shortcuts that simplify this for beginners, with a
full cheat sheet and a ten-question self-check as reference views.

Implementation notes:

- Lives in src/_hvac/ as build input and ships its own JS and CSS bundle,
  so /hvac and the rest of the site each load only what they need.
- Lesson content is data, not markup: block lists in src/_hvac/data/ map
  to small renderers in components/Prose.jsx.
- All arithmetic is pure and lives in lib/ductMath.js, verified against
  published ductulator capacities and the ASHRAE equivalent-diameter
  table. Wires up npm test, which had no test command before.
- No dependencies beyond react and react-dom — routing is the URL hash,
  state is useState plus localStorage.
- build-assets.js now takes a list of JS and Sass entry points instead of
  one hardcoded pair.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMDYgNEwkUqx9xeaB2NJBq